### PR TITLE
Adding markdown tile HTML examples

### DIFF
--- a/get-started/exploring-data/dashboards.mdx
+++ b/get-started/exploring-data/dashboards.mdx
@@ -70,6 +70,43 @@ One option that isn't available in the editor is text centering. That can be ach
 <h2 style="text-align:center">This is my centered title</h2>
 ```
 
+<Accordion title="Other HTML Markdown Tile options">
+  
+There are a number of other inline HTML options available through Markdown Tiles. Below are some examples:
+
+```markdown
+Check out this <b>bold</b> word.
+You can also do <i>italics</i>.
+And even <u>underline</u>.
+Or maybe you want to <s>strikethrough</s>. 
+
+Show code snippets like <code>Hello World!</code>. 
+Or <mark>highlight</mark> something important. 
+
+Add links like <a href="https://docs.lightdash.com/">this!</a> 
+
+Use <sub>subscript</sub> or <sup>superscript</sup> 
+
+<p style="color:red">Easily colour your text.</p>
+<p style="font-size:20px">Or change the size.</p>
+<p style="text-align:center">Center your text.</p>
+<p style="text-align:right">Or align it to the right.</p>
+<p style="text-align:justify">You can even justify a line of text if you are trying to communicate something particularly long, perhaps something like this example sentence?</p>
+<p style="word-spacing:5px">Change the word spacing. 👏</p>
+<p style="font-style:italic;font-weight:bold;color:blue">
+    Or combine a whole bunch of styles together.
+</p>
+
+<h1>We also support headings</h1>
+<h2 style="color:red">Here's an H2 heading in red</h2>
+
+You can also include images and apply different alt options and styles. Here'e one I centered earlier:
+
+<img src="https://placehold.co/300x200" alt="Centered Image" style="display:block;margin:0 auto" />
+```
+
+</Accordion>
+
 ### Loom videos
 
 All you need to do for embedding Loom videos is click on the Loom video option and enter a URL and title for the tile.

--- a/get-started/exploring-data/dashboards.mdx
+++ b/get-started/exploring-data/dashboards.mdx
@@ -70,9 +70,9 @@ One option that isn't available in the editor is text centering. That can be ach
 <h2 style="text-align:center">This is my centered title</h2>
 ```
 
-<Accordion title="Other HTML Markdown Tile options">
+<Accordion title="Other HTML markdown tile options">
   
-There are a number of other inline HTML options available through Markdown Tiles. Below are some examples:
+There are a number of other inline HTML options available. Below are some examples - Copy and paste them into a markdown tile to check them out!
 
 ```markdown
 Check out this <b>bold</b> word.
@@ -91,7 +91,7 @@ Use <sub>subscript</sub> or <sup>superscript</sup>
 <p style="font-size:20px">Or change the size.</p>
 <p style="text-align:center">Center your text.</p>
 <p style="text-align:right">Or align it to the right.</p>
-<p style="text-align:justify">You can even justify a line of text if you are trying to communicate something particularly long, perhaps something like this example sentence?</p>
+<p style="text-align:justify">You can even justify a line of text if you are trying to communicate a point that is particularly long, perhaps something like this example sentence?</p>
 <p style="word-spacing:5px">Change the word spacing. 👏</p>
 <p style="font-style:italic;font-weight:bold;color:blue">
     Or combine a whole bunch of styles together.
@@ -100,7 +100,7 @@ Use <sub>subscript</sub> or <sup>superscript</sup>
 <h1>We also support headings</h1>
 <h2 style="color:red">Here's an H2 heading in red</h2>
 
-You can also include images and apply different alt options and styles. Here'e one I centered earlier:
+You can also include images and apply different alt options and styles. Here's one I centered earlier:
 
 <img src="https://placehold.co/300x200" alt="Centered Image" style="display:block;margin:0 auto" />
 ```


### PR DESCRIPTION
A few questions came through recently that could have been answered with some docs around what html options are available in markdown tiles.

I think for most users, our current wysiwyg editor is fine, so I hid this behind an accordion.

I can post an screen grab of the tile this generates if we feel it would be better!