### PR TITLE
Fix: Update GitHub Footer Link to New Repository  

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -552,7 +552,7 @@
     }
   ],
   "footerSocials": {
-    "github": "https://github.com/lightdash/lightdash",
+    "github": "https://github.com/lightdash/mintlify-docs",
     "slack": "https://join.slack.com/t/lightdash-community/shared_invite/zt-2uwa5s9jl-xTNyjJ7otC8wH3jB8qgCpA",
     "linkedin": "https://www.linkedin.com/company/lightdash/",
     "x": "https://x.com/lightdash_devs"


### PR DESCRIPTION
### Description (Closes #9)
This PR updates the GitHub link in the footer to point to the correct repository:  
`https://github.com/lightdash/mintlify-docs`.  

### Changes  
- Updated the `github` value in the `footerSocials` section of `mint.json`.  

### Before  
```json
"footerSocials": {
  "github": "https://github.com/lightdash/lightdash"
}
```

### After  
```json
"footerSocials": {
  "github": "https://github.com/lightdash/mintlify-docs"
}
```

### Testing  
1. Navigate to the documentation and scroll to the footer.  
2. Click the **GitHub** icon.  
3. Confirm that it redirects to the `mintlify-docs` repository.  