### PR TITLE
docs: render markdown links correctly inside <Accordion> block

### DIFF
--- a/get-started/setup-lightdash/get-project-lightdash-ready.mdx
+++ b/get-started/setup-lightdash/get-project-lightdash-ready.mdx
@@ -11,7 +11,7 @@ In Lightdash, everything you need for BI is written as code in your dbt project.
 But, before you hook up your dbt project to Lightdash, we need to make sure we have Tables to explore. **In this setup guide, we'll walk you through the steps of installing + using the Lightdash CLI and creating the first Tables in your project.**
 
 <Tip>
-  **New to dbt?** If you haven't used dbt before, [follow dbt's getting started guide](https://docs.getdbt.com/tutorial/setting-up)before proceeding with setting up Lightdash.
+  **New to dbt?** If you haven't used dbt before, [follow dbt's getting started guide](https://docs.getdbt.com/tutorial/setting-up) before proceeding with setting up Lightdash.
 </Tip>
 
 ## What are Tables?
@@ -132,7 +132,7 @@ For example, if we have a `projects.yml` file, we'd have a Table called `Project
 <Accordion title="If you only want to generate Tables and dimensions for ***some*** of the models in your dbt project, check this out">
   ### Generate Tables and dimensions for some of the models in my dbt project:
 
-  There may be a specific set of models that you want to start out with as Tables in Lightdash. If this is the case, we recommend \[using dbt's `tags`]\(https://docs.getdbt.com/reference/resource-configs/tags) to tag these models. You can use sets of existing tags, or you can create a new Lightdash-specific tag. Something like this:
+  There may be a specific set of models that you want to start out with as Tables in Lightdash. If this is the case, we recommend <a href="https://docs.getdbt.com/reference/resource-configs/tags">using dbt's <code>tags</code></a> to tag these models. You can use sets of existing tags, or you can create a new Lightdash-specific tag. Something like this:
 
   ```bash
   {{


### PR DESCRIPTION
### Description (Closes #8)
Replaced the Markdown-style link:

```jsx
[using dbt's `tags`](https://docs.getdbt.com/reference/resource-configs/tags)
```

with an HTML `<a>` tag:

```jsx
<a href="https://docs.getdbt.com/reference/resource-configs/tags">using dbt's <code>tags</code></a>
```

This ensures the link renders correctly across environments while preserving the `<Accordion>` formatting.

### Screenshots  
**Before:**  
![image](https://github.com/user-attachments/assets/3d6492fd-d4bd-4458-989a-fcabf6a0d2af)

**After:**  
![image](https://github.com/user-attachments/assets/92c309aa-aedf-48ec-884a-f535abe9dbbd)
