### PR TITLE
Adding CLI commands to reference tables

### DIFF
--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -86,22 +86,22 @@ The table below includes a complete list of all commands available in the Lightd
 
 For examples and command-specific options, click through the command in the table for docs, or install the Lightdash CLI and use the [global help option](#help).
 
-| Command | Description                                                                     |
-| ------- | ------------------------------------------------------------------------------- |
-|lightdash login         | Log in to a Lightdash instance using email/password or a token                  |
-|         | Choose or set the Lightdash project you are working on                          |
-|         | Compile lightdash resources using your local project files                      |
-|         | Create a temporary preview project, then wait for a keypress to stop            |
-|         | Create a preview project that stays open until it is stopped                    |
-|         | Shut down an open preview project                                               |
-|         | Compile and deploy a Lightdash project using your local project and credentials |
-|         | Refresh Lightdash project with remote repository                                |
-|         | Validates content from your active project against your local project files     |
-|         | Generates or updates schema.yml file(s) for the selected model(s)               |
-|         | \[Experimental command\] Generates a .yml file for Lightdash exposures          |
-|         |                                                                                 |
-|         | Downloads all charts and dashboards from your Lightdash project as code         |
-|         | Uploads all updates to charts and dashboards as code to your Lightdash project  |
+| Command                      | Description                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+|`lightdash login`             | Log in to a Lightdash instance using email/password or a token                     |
+|`lightdash config set-project`| Choose or set the Lightdash project you are working on                             |
+|`lightdash compile`           | Compile lightdash resources using your local project files                         |
+|`lightdash preview`           | Create a temporary preview project, then wait for a keypress to stop               |
+|`lightdash start-preview`     | Create a preview project that stays open until it is stopped                       |
+|`lightdash stop-preview`      | Shut down an open preview project                                                  |
+|`lightdash deploy`            | Compile and deploy a Lightdash project using your local project and credentials    |
+|`lightdash refresh`           | Refresh Lightdash project with remote repository                                   |
+|`lightdash validate`          | Validates content from your active project against your local project files        |
+|`lightdash generate`          | Generates or updates schema.yml file(s) for the selected model(s)                  |
+|`lightdash dbt run`           | Runs dbt and then generates or updates schema.yml file(s) for the selected model(s)|
+|`lightdash generate-exposures`| \[Experimental command\] Generates a .yml file for Lightdash exposures             |
+|`lightdash download`          | Downloads all charts and dashboards from your Lightdash project as code            |
+|`lightdash upload`            | Uploads all updates to charts and dashboards as code to your Lightdash project     |
 
 ---
 

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -88,7 +88,7 @@ For examples and command-specific options, click through the command in the tabl
 
 | Command | Description                                                                     |
 | ------- | ------------------------------------------------------------------------------- |
-|         | Log in to a Lightdash instance using email/password or a token                  |
+|lightdash login         | Log in to a Lightdash instance using email/password or a token                  |
 |         | Choose or set the Lightdash project you are working on                          |
 |         | Compile lightdash resources using your local project files                      |
 |         | Create a temporary preview project, then wait for a keypress to stop            |


### PR DESCRIPTION
During the docs migration, i think these went missing. Adding them back in!