### PR TITLE
docs: document --preserve-column-case flag

### DIFF
--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -387,6 +387,9 @@ All standard [dbt options](#dbt-options) work with `lightdash generate`.
 - `--exclude-meta`
   - (default: false)
   - exclude Lightdash metadata from the generated .yml
+- `--preserve-column-case`
+  - (default: false)
+  - preserve original casing of column names in generated schema files
 
 **Example:**
 
@@ -439,6 +442,9 @@ Any dbt option that works with `dbt run` will also work with `lightdash dbt run`
   - assume yes to prompts (default: false)
 - `-no` or `--assume-no`
   - assume no to prompts (default: false)
+- `--preserve-column-case`
+  - (default: false)
+  - preserve original casing of column names in generated schema files
 
 **Examples:**
 


### PR DESCRIPTION
Refers to: https://app.graphite.dev/github/pr/lightdash/lightdash/14804/feat(cli)-flag-to-preserve-original-casing-of-column-names-in-generated-schema-files