### PR TITLE
chore: rename RESULTS_CACHE variables

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -87,31 +87,42 @@ These variables enable you to control Single Sign On (SSO) functionality.
 
 These variables allow you to configure [S3 Object Storage](/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage).
 
-| Variable              | Description                                                                                                                               | Required?                                     | Default     |
-| :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------: | :---------: |
-| `S3_ENDPOINT`         | S3 endpoint for storing cached results                                                                                                    | <Icon icon="square-check" iconType="solid" /> |             |
-| `S3_BUCKET`           | Name of the S3 bucket for storing files                                                                                                   | <Icon icon="square-check" iconType="solid" /> |             |
-| `S3_REGION`           | Region where the S3 bucket is located                                                                                                     | <Icon icon="square-check" iconType="solid" /> |             |
-| `S3_ACCESS_KEY`       | Access key for authenticating with the S3 bucket                                                                                          |                                               |             |
-| `S3_SECRET_KEY`       | Secret key for authenticating with the S3 bucket                                                                                          |                                               |             |
-| `S3_EXPIRATION_TIME`  | Expiration time for scheduled deliveries files                                                                                            |                                               | 259200 (3d) |
-| `S3_FORCE_PATH_STYLE` | Force path style addressing, needed for MinIO setup e.g. `http://your.s3.domain/BUCKET/KEY` instead of `http://BUCKET.your.s3.domain/KEY` |                                               | `false`     |
+| Variable               | Description                                                                                                                               | Required?                                     | Default        |
+| :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------: | :------------: |
+| `S3_ENDPOINT`          | S3 endpoint for storing results                                                                                                           | <Icon icon="square-check" iconType="solid" /> |                |
+| `S3_BUCKET`            | Name of the S3 bucket for storing files                                                                                                   | <Icon icon="square-check" iconType="solid" /> |                |
+| `S3_REGION`            | Region where the S3 bucket is located                                                                                                     | <Icon icon="square-check" iconType="solid" /> |                |
+| `S3_ACCESS_KEY`        | Access key for authenticating with the S3 bucket                                                                                          |                                               |                |
+| `S3_SECRET_KEY`        | Secret key for authenticating with the S3 bucket                                                                                          |                                               |                |
+| `S3_EXPIRATION_TIME`   | Expiration time for scheduled deliveries files                                                                                            |                                               | 259200 (3d)    |
+| `S3_FORCE_PATH_STYLE`  | Force path style addressing, needed for MinIO setup e.g. `http://your.s3.domain/BUCKET/KEY` instead of `http://BUCKET.your.s3.domain/KEY` |                                               | `false`        |
+| `RESULTS_S3_BUCKET`    | Name of the S3 bucket used for storing query results                                                                                      |                                               | `S3_BUCKET`    |
+| `RESULTS_S3_REGION`    | Region where the S3 query storage bucket is located                                                                                       |                                               | `S3_REGION`    |
+| `RESULTS_S3_ACCESS_KEY`| Access key for authenticating with the S3 query storage bucket                                                                            |                                               | `S3_ACCESS_KEY`|
+| `RESULTS_S3_SECRET_KEY`| Secret key for authenticating with the S3 query storage bucket                                                                            |                                               | `S3_SECRET_KEY`|
 
 ## Cache
+
+<Info>
+  Note that you will need an Enterprise License Key for this functionality.
+</Info>
 
 | Variable                      | Description                                                                | Required? | Default         |
 | :---------------------------- | :------------------------------------------------------------------------- | :-------: | :-------------: |
 | `RESULTS_CACHE_ENABLED`       | Enables caching for chart results                                          |           | `false`         |
 | `AUTOCOMPLETE_CACHE_ENABLED`  | Enables caching for filter autocomplete results                            |           | `false`         |
-| `RESULTS_CACHE_S3_BUCKET`     | Name of the S3 bucket used for caching query results                       |           | `S3_BUCKET`     |
-| `RESULTS_CACHE_S3_REGION`     | Region where the S3 bucket is located                                      |           | `S3_REGION`     |
-| `RESULTS_CACHE_S3_ACCESS_KEY` | Access key for authenticating with the S3 bucket                           |           | `S3_ACCESS_KEY` |
-| `RESULTS_CACHE_S3_SECRET_KEY` | Secret key for authenticating with the S3 bucket                           |           | `S3_SECRET_KEY` |
 | `CACHE_STALE_TIME_SECONDS`    | Defines how long cached results remain valid before being considered stale |           | 86400 (24h)     |
 
 <Info>
-  Note that you will need an Enterprise License Key for this functionality.
+  These variables are **deprecated**; use the `RESULTS_S3_*` versions instead.
 </Info>
+
+| Variable                      | Description                                                                | Required? | Default         |
+| :---------------------------- | :------------------------------------------------------------------------- | :-------: | :-------------: |
+| `RESULTS_CACHE_S3_BUCKET`     | Deprecated - use RESULTS_S3_BUCKET                                         |           | `S3_BUCKET`     |
+| `RESULTS_CACHE_S3_REGION`     | Deprecated - use RESULTS_S3_REGION                                         |           | `S3_REGION`     |
+| `RESULTS_CACHE_S3_ACCESS_KEY` | Deprecated - use RESULTS_S3_ACCESS_KEY                                     |           | `S3_ACCESS_KEY` |
+| `RESULTS_CACHE_S3_SECRET_KEY` | Deprecated - use RESULTS_S3_SECRET_KEY                                     |           | `S3_SECRET_KEY` |
 
 ## Logging
 


### PR DESCRIPTION
Add docs to deprecate `RESULTS_CACHE_*` variables