### PR TITLE
Add business user training videos

### DIFF
--- a/get-started/exploring-data/intro.mdx
+++ b/get-started/exploring-data/intro.mdx
@@ -6,4 +6,29 @@ sidebarTitle: Overview
 ---
 
 
-<CardGroup cols={2} > <Card title="Exploring your content" icon="compass" href="/get-started/exploring-data/exploring-your-content" iconType="solid" horizontal/> <Card title="Intro to metrics and dimensions" icon="chart-simple" href="/get-started/exploring-data/intro-metrics-dimensions" iconType="solid" horizontal/> <Card title="Using Tables and Explore View" icon="table" href="/get-started/exploring-data/using-explores"iconType="solid" horizontal /> <Card title="Share insights with your team" icon="share-nodes" href="/get-started/exploring-data/sharing-insights" iconType="solid" horizontal/> <Card title="Creating dashboards" icon="rocket" href="/get-started/exploring-data/dashboards" iconType="solid" horizontal/> </CardGroup>
+<CardGroup cols={2} > 
+    <Card title="Exploring your content" icon="compass" href="/get-started/exploring-data/exploring-your-content" iconType="solid" horizontal/> 
+    <Card title="Intro to metrics and dimensions" icon="chart-simple" href="/get-started/exploring-data/intro-metrics-dimensions" iconType="solid" horizontal/> 
+    <Card title="Using Tables and Explore View" icon="table" href="/get-started/exploring-data/using-explores"iconType="solid" horizontal /> 
+    <Card title="Share insights with your team" icon="share-nodes" href="/get-started/exploring-data/sharing-insights" iconType="solid" horizontal/> 
+    <Card title="Creating dashboards" icon="rocket" href="/get-started/exploring-data/dashboards" iconType="solid" horizontal/> 
+</CardGroup>
+
+## Videos
+
+If you would prefer to take a guided tour by video, you can check out our videos on exploration in Lightdash. Note that these videos use data available in [demo.lightdash.com](https://demo.lightdash.com), so you can follow along! 
+
+The below videos are split into chapters. This allows you can easily move to different parts of the video to get what you need using the progress bar.
+
+The first video covers the **fundamentals** of Lightdash - Dashboards, charts, metrics, dimensions and how to explore independently.
+
+<Frame>
+  <iframe width="100%" height="420" src="https://www.loom.com/embed/3baada5e1d9e479da0dbe12e8a54121e?sid=2527066a-c9df-416c-b4a6-68e920029519" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+</Frame>
+
+If you want to explore more **advanced functionality**, such as custom metrics, table calculations, advanced chart config and more, check out the advanced topics below.
+
+<Frame>
+  <iframe width="100%" height="420" src="https://www.loom.com/embed/ffcb6754146a49b9acc6fb5e5e90e7a3?sid=91a43128-7b36-438d-94b3-e7a0425d0baf" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+</Frame>
+

--- a/get-started/exploring-data/intro.mdx
+++ b/get-started/exploring-data/intro.mdx
@@ -14,13 +14,13 @@ sidebarTitle: Overview
     <Card title="Creating dashboards" icon="rocket" href="/get-started/exploring-data/dashboards" iconType="solid" horizontal/> 
 </CardGroup>
 
-## Videos
+## Video Guides
 
 If you would prefer to take a guided tour by video, you can check out our videos on exploration in Lightdash. Note that these videos use data available in [demo.lightdash.com](https://demo.lightdash.com), so you can follow along! 
 
-The below videos are split into chapters. This allows you can easily move to different parts of the video to get what you need using the progress bar.
+The below videos are split into chapters. This allows you to easily move to different parts of the video to get what you need using the progress bar.
 
-The first video covers the **fundamentals** of Lightdash - Dashboards, charts, metrics, dimensions and how to explore independently.
+The first video covers the **fundamentals** of Lightdash - Dashboards, charts, metrics, dimensions and how to explore data on your own.
 
 <Frame>
   <iframe width="100%" height="420" src="https://www.loom.com/embed/3baada5e1d9e479da0dbe12e8a54121e?sid=2527066a-c9df-416c-b4a6-68e920029519" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />


### PR DESCRIPTION
Added videos to the get-started/exploring-data into page.

Maybe these would be better suited elsewhere? We had talked about them being on the homepage, but feels like something shorter/snappier belongs there!