### PR TITLE
docs: Define feature maturity levels

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -196,18 +196,13 @@
               },
               {
                 "group": "User",
-                "pages": [
-                  "references/user",
-                  "references/personal_tokens"
-                ]
+                "pages": ["references/user", "references/personal_tokens"]
               },
               {
                 "group": "Embedding",
-                "pages": [
-                  "references/embedding",
-                  "references/react-sdk"
-                ]
-              }
+                "pages": ["references/embedding", "references/react-sdk"]
+              },
+              "references/feature-maturity-levels"
             ]
           },
           {

--- a/references/feature-maturity-levels.mdx
+++ b/references/feature-maturity-levels.mdx
@@ -1,0 +1,54 @@
+---
+title: "Feature Maturity Levels"
+description: "We use standardized maturity levels to help you understand the stability and availability of features as we develop them"
+sidebarTitle: "Feature Maturity Levels"
+---
+
+## Feature lifecycle
+
+```mermaid
+flowchart LR
+    A(Experimental) --> B("Early Access")
+    B --> C("Generally Available (GA)")
+    
+    style A fill:#99F4D1,stroke:#99F4D1,color:#000
+    style B fill:#D6C1FA,stroke:#D6C1FA,color:#000
+    style C fill:#7262FF,stroke:#D6C1FA,color:#fff
+
+    linkStyle 0,1 stroke:#c0c0c0,stroke-with:1px
+```
+
+### Experimental
+
+Experimental features are where we explore new ideas and test out proof of concepts.
+
+- We're still building out core functionality, so things may be incomplete or unstable
+- We might make breaking changes without much notice as we iterate
+- We limit access to our internal team and design partners
+- Our design partners help us figure out what the feature should do and how it should work
+- We're in full feedback-driven development mode
+
+### Early Access
+
+Early Access features are stable and work well, but we're still actively testing and improving them based on your feedback.
+
+- Work smoothly with good performance
+- We might still make some changes based on what you tell us
+- We provide comprehensive documentation
+- Breaking changes are rare, and we'll always give you plenty of notice
+- Our support team is ready to help
+- We might put some usage limits in place while we fine-tune things
+- We're getting these features ready for our full GA release
+
+### Generally Available (GA)
+
+GA features are production-ready and fully supported by our team.
+
+- We provide complete documentation and training materials
+- These features are stable with our commitment to backward compatibility
+
+## Using Feature Maturity Levels
+
+These levels help you understand what to expect from each feature's stability and performance, so you can decide what works best for your production environment and risk tolerance.
+
+When you're evaluating features for your use case, we recommend considering the maturity level alongside your requirements for stability, support, and backward compatibility.

--- a/references/references.mdx
+++ b/references/references.mdx
@@ -48,4 +48,8 @@ mode: wide
   <Card title="SCIM Integration" href="/references/scim-integration" icon="file-lines" iconType="solid" horizontal>
   SCIM Integration is only available on...
   </Card>
+  
+  <Card title="Feature Maturity Levels" href="/references/feature-maturity-levels" icon="file-lines" iconType="solid" horizontal>
+    Standardized levels that communicate...
+  </Card>
 </CardGroup>


### PR DESCRIPTION
### TL;DR
Added documentation for Feature Maturity Levels to help users understand how stable our features are and who can access them.

### Why make this change?
We needed a clearer way to help users understand what to expect from features as we develop them. This documentation explains it in a way so they can make informed decisions about which features work best for their needs and risk comfort level