### PR TITLE
Add dbt 1.10+ syntax examples for AI agent tagging

### DIFF
--- a/guides/ai-agents.mdx
+++ b/guides/ai-agents.mdx
@@ -67,7 +67,7 @@ AI agents in Lightdash allow you to:
 Connect your AI agents to Slack for collaborative data analysis and team-wide insights sharing, here's how:
 
 1. Select or create an AI agent in your Lightdash instance
-2. Add the [Slack integration](https://docs.lightdash.com/guides/using-slack-integration#using-the-slack-integration) in your organization settings 
+2. Add the [Slack integration](https://docs.lightdash.com/guides/using-slack-integration#using-the-slack-integration) in your organization settings
 3. Under 'Integrations', add the channel you want to use
    {" "}
    <Frame>
@@ -175,7 +175,30 @@ Use tags to control which metrics and dimensions each AI agent can access. This 
 
 Tag entire models to give your AI agent access to all metrics and dimensions within that explore:
 
-```bash
+<CodeGroup>
+
+
+```yaml dbt 1.10+
+models:
+  - name: marketing_campaigns
+    config:
+      meta:
+        tags: ['marketing', 'ai']  #    <--------- tagging the entire model
+    columns:
+      - name: campaign_name
+        config:
+          meta:
+            dimension:
+              type: string
+      - name: impressions
+        config:
+          meta:
+            metrics:
+              total_impressions:
+                type: sum
+```
+
+```yaml dbt <=1.9
 models:
   - name: marketing_campaigns
     meta:
@@ -192,11 +215,41 @@ models:
               type: sum
 ```
 
+</CodeGroup>
+
 #### Adding tags to individual metrics & dimensions
 
 For more granular control, tag specific metrics and dimensions:
 
-```bash
+<CodeGroup>
+
+```yaml dbt 1.10+
+models:
+  - name: orders
+    columns:
+      - name: status
+        config:
+          meta:
+            dimension:
+              tags: ['ai', 'sales']  # <--------- tagging the dimension
+      - name: location
+        config:
+          meta:
+            dimension:
+              tags: ['ai', 'operations']  # <--------- taggint the dimension
+      - name: amount
+        description: Total amount of the order
+        config:
+          meta:
+            metrics:
+              total_order_amount:
+                type: sum
+                format: usd
+                round: 2
+                tags: ['ai', 'finance']  # <--------- tagging the metric
+```
+
+```yaml dbt <=1.9
 - name: orders
   columns:
     - name: status
@@ -206,7 +259,7 @@ For more granular control, tag specific metrics and dimensions:
      - name: location
       meta:
         dimension:
-          tags: ['ai', 'operations'] #    <--------- adding many tags
+          tags: ['ai', 'operations'] #    <--------- taggint the dimension
     - name: amount
       description: Total amount of the order
       meta:
@@ -217,6 +270,8 @@ For more granular control, tag specific metrics and dimensions:
             round: 2
             tags: ['ai', 'finance'] #    <--------- tagging the metric
 ```
+
+</CodeGroup>
 
 ## FAQs
 


### PR DESCRIPTION
This PR updates the AI agents documentation to include the new tagging syntax for dbt 1.10+