### PR TITLE
added a note to clarify that creating previews from branches is github only

### DIFF
--- a/references/preview-projects.mdx
+++ b/references/preview-projects.mdx
@@ -53,11 +53,17 @@ You can leave out the **branch** and **schema** fields and you'll get a preview 
 
 **Creating a preview project from a Github branch**
 
+
+
 By choosing a branch (and optionally setting a schema or environment variables) you can create a preview project that uses code from a different branch than your main project. This is perfect for previewing changes you made on a branch in dbt Cloud or quick edits where you don't want to fire up the CLI.
 
 <Tip>
-  Preview projects from branches are a great solution for team members who don't have local development or the CLI set up.
+  Preview projects created from branches in the Lightdash UI are perfect when team members need to review changes but don't have a local development environment set up. 
 </Tip>
+
+<Info> 
+  Note: this only works with GitHub. It is currently not possible to create previews from GitLab branches in the Lightdash App UI. 
+</Info>
 
 ### Pull Requests (GitHub Actions)
 

--- a/references/preview-projects.mdx
+++ b/references/preview-projects.mdx
@@ -58,7 +58,7 @@ You can leave out the **branch** and **schema** fields and you'll get a preview 
 By choosing a branch (and optionally setting a schema or environment variables) you can create a preview project that uses code from a different branch than your main project. This is perfect for previewing changes you made on a branch in dbt Cloud or quick edits where you don't want to fire up the CLI.
 
 <Tip>
-  Preview projects created from branches in the Lightdash UI are perfect when team members need to review changes but don't have a local development environment set up. 
+  Preview projects from GitHub branches are a great solution for team members who don't have local development or the CLI set up.
 </Tip>
 
 <Info> 


### PR DESCRIPTION
Added disclaimer to ensure that GitLab users know that we only support creating of previews from branches for GitHub and not GitLab.  
<img width="607" height="290" alt="image" src="https://github.com/user-attachments/assets/cb8fa0b2-d10a-4023-9c3c-c5c8c8246b00" />
