### PR TITLE
docs: update AI Analyst configuration documentation

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -189,22 +189,48 @@ These variables allow you to configure [S3 Object Storage](/self-host/customize-
 
 These variables enable you to configure the [AI Analyst functionality](guides/ai-analyst.mdx). Note that you will need an **Enterprise Licence Key** for this functionality.
 
-| Variable                              | Description                                                              | Required?                                     | Default |
-| ------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------- | ------- |
-| `OPENAI_API_KEY`                      | Required for AI Analyst                                                  | <Icon icon="square-check" iconType="solid" /> |         |
-| `OPENAI_MODEL_NAME`                   | Required for AI Analyst                                                  | <Icon icon="square-check" iconType="solid" /> |         |
-| `AI_COPILOT_ENABLED`                  | Required for AI Analyst                                                  | <Icon icon="square-check" iconType="solid" /> |         |
-| `OPENAI_BASE_URL`                     | Optional base url for OpenAI compatible API                              |                                               |         |
-| `AI_COPILOT_EMBEDDING_SEARCH_ENABLED` | Experimental. Required for the AI Analyst to use semantic search to find relevant data |                                               |         |
-| `AI_COPILOT_TELEMETRY_ENABLED`        | Enables telemetry for AI Copilot                                         |                                               | `false` |
-| `AI_COPILOT_REQUIRES_FEATURE_FLAG`    | Requires a feature flag to use AI Copilot                                |                                               | `false` |
-| `AI_DEFAULT_PROVIDER`                 | Default AI provider to use                                               |                                               |         |
-| `ANTHROPIC_API_KEY`                   | API key for Anthropic                                                    |                                               |         |
-| `ANTHROPIC_MODEL_NAME`                | Model name for Anthropic                                                 |                                               |         |
-| `AZURE_AI_API_KEY`                    | API key for Azure AI                                                     |                                               |         |
-| `AZURE_AI_ENDPOINT`                   | Endpoint for Azure AI                                                    |                                               |         |
-| `AZURE_AI_API_VERSION`                | API version for Azure AI                                                 |                                               |         |
-| `AZURE_AI_DEPLOYMENT_NAME`            | Deployment name for Azure AI                                             |                                               |         |
+| Variable                              | Description                                                              | Required?                                     | Default                         |
+| ------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------- | ------------------------------- |
+| `AI_COPILOT_ENABLED`                  | Enables/Disables AI Analyst functionality                                | <Icon icon="square-check" iconType="solid" /> |                                 |
+| `AI_DEFAULT_PROVIDER`                 | Default AI provider to use (`openai`, `azure`, `anthropic`, `openrouter`) |                                               | `openai`                        |
+| `AI_COPILOT_DEBUG_LOGGING_ENABLED`    | Enables debug logging for AI Copilot                                     |                                               | `false`                         |
+| `AI_COPILOT_TELEMETRY_ENABLED`        | Enables telemetry for AI Copilot                                         |                                               | `false`                         |
+| `AI_COPILOT_REQUIRES_FEATURE_FLAG`    | Requires a feature flag to use AI Copilot                                |                                               | `false`                         |
+
+The AI Analyst supports multiple providers for flexibility. Choose one of the provider configurations below based on your preferred AI service. **OpenAI integration is the recommended option as it is the most tested and stable implementation.**
+
+#### OpenAI Configuration
+
+| Variable                | Description                                                | Required?                                     | Default     |
+| ----------------------- | ---------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `OPENAI_API_KEY`        | API key for OpenAI                                         | Required when using OpenAI                    |             |
+| `OPENAI_MODEL_NAME`     | OpenAI model name to use                                   |                                               | `gpt-4.1`   |
+| `OPENAI_BASE_URL`       | Optional base URL for OpenAI compatible API                |                                               |             |
+
+#### Anthropic Configuration
+
+| Variable                | Description                                                | Required?                                     | Default                         |
+| ----------------------- | ---------------------------------------------------------- | --------------------------------------------- | ------------------------------- |
+| `ANTHROPIC_API_KEY`     | API key for Anthropic                                      | Required when using Anthropic                 |                                 |
+| `ANTHROPIC_MODEL_NAME`  | Anthropic model name to use                                |                                               | `claude-4-sonnet-20250514`      |
+
+#### Azure AI Configuration
+
+| Variable                   | Description                                              | Required?                                     | Default |
+| -------------------------- | -------------------------------------------------------- | --------------------------------------------- | ------- |
+| `AZURE_AI_API_KEY`         | API key for Azure AI                                     | Required when using Azure AI                  |         |
+| `AZURE_AI_ENDPOINT`        | Endpoint for Azure AI                                    | Required when using Azure AI                  |         |
+| `AZURE_AI_API_VERSION`     | API version for Azure AI                                 | Required when using Azure AI                  |         |
+| `AZURE_AI_DEPLOYMENT_NAME` | Deployment name for Azure AI                             | Required when using Azure AI                  |         |
+
+#### OpenRouter Configuration
+
+| Variable                     | Description                                            | Required?                                     | Default                           |
+| ---------------------------- | ------------------------------------------------------ | --------------------------------------------- | --------------------------------- |
+| `OPENROUTER_API_KEY`         | API key for OpenRouter                                 | Required when using OpenRouter                |                                   |
+| `OPENROUTER_MODEL_NAME`      | OpenRouter model name to use                          |                                               | `openai/gpt-4.1-2025-04-14`      |
+| `OPENROUTER_SORT_ORDER`      | Provider sorting method (`price`, `throughput`, `latency`) |                                               | `latency`                         |
+| `OPENROUTER_ALLOWED_PROVIDERS`| Comma-separated list of allowed providers (`anthropic`, `openai`, `google`) |                                               | `openai`                          |
 
 ## Slack Integration
 


### PR DESCRIPTION
# Improved AI Analyst Configuration Documentation

- Organized variables into logical provider-specific sections (OpenAI, Anthropic, Azure AI, and OpenRouter)
- Added OpenRouter as a new supported AI provider with relevant configuration options
- Updated default values for model names across providers
- Clarified which variables are required for each specific provider
- Added a recommendation note that OpenAI is the most tested and stable implementation
