### PR TITLE
docs: update environment variables documentation for Instance Init/Update

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -372,7 +372,7 @@ For more information on our plans, visit our [pricing page](https://www.lightdas
 | :------------------------------------ | :------------------------------------------------------------------------------------------------ | :-------------------------------------------: | :----------: |
 | `LD_SETUP_ADMIN_NAME`                 | Name of the admin user for initial setup                                                          |                                               | `Admin User` |
 | `LD_SETUP_ADMIN_EMAIL`                | Email of the admin user for initial setup                                                         | <Icon icon="square-check" iconType="solid" /> |              |
-| `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN`  | Email domain for the organization whitelisting                                                    |                                               |              |
+| `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN`  | Comma-separated list of email domains for organization whitelisting                              |                                               |              |
 | `LD_SETUP_ORGANIZATION_DEFAULT_ROLE`  | Default role for new organization members                                                         |                                               | `viewer`     |
 | `LD_SETUP_ORGANIZATION_NAME`          | Name of the organization                                                                          | <Icon icon="square-check" iconType="solid" /> |              |
 | `LD_SETUP_ADMIN_API_KEY`              | API key for the admin user, must start with `ldpat_` prefix                                       | <Icon icon="square-check" iconType="solid" /> |              |
@@ -411,7 +411,7 @@ On server start, we will check the following variables, and update some configur
 
 <Info>
 
-**Initialize instance is only available on Lightdash Enterprise plans.**
+**Update instance is only available on Lightdash Enterprise plans.**
 
 For more information on our plans, visit our [pricing page](https://www.lightdash.com/pricing).
 </Info>
@@ -420,8 +420,11 @@ For more information on our plans, visit our [pricing page](https://www.lightdas
 | Variable                              | Description                                                                                       | Required?                                     | Default      |
 | :------------------------------------ | :------------------------------------------------------------------------------------------------ | :-------------------------------------------: | :----------: |
 | `LD_SETUP_ADMIN_EMAIL`                | Email of the admin to update its Personal access token                                                         | Required if `LD_SETUP_ADMIN_API_KEY` is present |              |
-| `LD_SETUP_ADMIN_API_KEY`  | API key for the admin user, must start with `ldpat_` prefix                                                    |                                               |              |
-| `LD_SETUP_PROJECT_HTTP_PATH`          | HTTP path for Databricks connection                                                               |  |              |
+| `LD_SETUP_ADMIN_API_KEY`              | API key for the admin user, must start with `ldpat_` prefix                                      |                                               |              |
+| `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN`  | Comma-separated list of email domains for organization whitelisting                              |                                               |              |
+| `LD_SETUP_ORGANIZATION_DEFAULT_ROLE`  | Default role for new organization members                                                         |                                               | `viewer`     |
+| `LD_SETUP_PROJECT_HTTP_PATH`          | HTTP path for Databricks connection                                                               |                                               |              |
+| `LD_SETUP_PROJECT_PAT`                | Personal access token for Databricks                                                              |                                               |              |
 | `LD_SETUP_DBT_VERSION`                | Version of dbt to use (eg: v1.8)                                                                  |                                               | `latest`     |
-| `LD_SETUP_GITHUB_PAT`                 | GitHub personal access token                                                                      |  |              |
-| `LD_SETUP_SERVICE_ACCOUNT_TOKEN`      | A pre-set token for the service account, must start with `ldsvc_` prefix                            | |              |
+| `LD_SETUP_GITHUB_PAT`                 | GitHub personal access token                                                                      |                                               |              |
+| `LD_SETUP_SERVICE_ACCOUNT_TOKEN`      | A pre-set token for the service account, must start with `ldsvc_` prefix                         |                                               |              |


### PR DESCRIPTION
This PR updates the environment variables documentation with the following improvements:

1. Clarified that `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN` accepts a comma-separated list of email domains for organization whitelisting

2. Added missing environment variables to the update instance section:
   - `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN`
   - `LD_SETUP_ORGANIZATION_DEFAULT_ROLE`
   - `LD_SETUP_PROJECT_PAT`
