### PR TITLE
added warning to post experimental metrics

### DIFF
--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -413,6 +413,9 @@ models:
 ```
 
 Note: If the previous value is 0 or NULL, the result will be NULL to avoid division-by-zero.
+<Warning>
+**This is a post calculation metric** which is computed after other metrics. It can only reference aggregate and non-aggregate metrics (and cannot reference dimensions or other post calculation metrics).
+</Warning>
 
 ### percent_of_total
 
@@ -433,6 +436,10 @@ models:
           format: '0.00%'
 ```
 
+<Warning>
+**This is a post calculation metric** which is computed after other metrics. It can only reference aggregate and non-aggregate metrics (and cannot reference dimensions or other post calculation metrics).
+</Warning>
+
 ### running_total
 
 Returns the cumulative total of a referenced metric according to the query's grouping and sort order.
@@ -450,6 +457,9 @@ models:
           type: running_total
           sql: ${total_revenue}
 ```
+<Warning>
+**This is a post calculation metric** which is computed after other metrics. It can only reference aggregate and non-aggregate metrics (and cannot reference dimensions or other post calculation metrics).
+</Warning>
 
 ## Description
 


### PR DESCRIPTION
We recently added post calculation metrics which can only reference other metrics not dimensions. I got tripped up on this so decided to add more documentation to the metrics to ensure users know that they only work with metrics. 
<img width="591" height="484" alt="percent_of_previous" src="https://github.com/user-attachments/assets/1baaf172-a179-4b7b-ae23-423b7d0626dc" />
