### PR TITLE
docs: update caching availability information

### DIFF
--- a/references/caching.mdx
+++ b/references/caching.mdx
@@ -3,10 +3,16 @@ title: "Caching"
 description: "Caching can reduce the overall number of queries that Lightdash executes against your data warehouse. Learn more about the types of caching and how to enable caching in this doc."
 ---
 
+:::info Availability
+Caching features are only available to:
+- **Lightdash Cloud customers** (all plans)
+- **On-premise customers with a valid License key**
+:::
+
 Lightdash supports two types of caching:
 
-1. [Cached Filter values](#filter-value-caching) - enabled for every cloud user without requiring any configuration.
-2. [Cached results for Charts and Dashboards](#chart-and-dashboard-results-caching) - must be enabled by the Lightdash team. This feature is only available for Pro, Enterprise, and on-prem users since it requires a dedicated Lightdash instance.
+1. **[Cached Filter values](#filter-value-caching)** - enabled for every cloud user without requiring any configuration.
+2. **[Cached results for Charts and Dashboards](#chart-and-dashboard-results-caching)** - only available for Cloud Pro or above and must be enabled by the Lightdash team.
 
 ## Filter value caching
 


### PR DESCRIPTION
# Update caching documentation with availability information

This PR adds an information box at the top of the caching documentation to clearly indicate that caching features are only available to Lightdash Cloud customers (all plans) and on-premise customers with a valid license key.

The PR also:
- Adds bold formatting to the two types of caching for better readability
- Updates the description of Chart and Dashboard results caching to specify it's only available for Cloud Pro or above

These changes help users better understand the availability requirements for caching features.