### PR TITLE
Remove redundant AI agents description

### DIFF
--- a/guides/ai-agents.mdx
+++ b/guides/ai-agents.mdx
@@ -38,8 +38,6 @@ This guide covers everything you need to know about AI agents in Lightdash:
   />
 </Frame>
 
-AI agents automatically select the most relevant data models and metrics to answer your questions, build and execute queries with appropriate dimensions, metrics, and filters, and present results in the most insightful format.
-
 
 ## Quick start
 


### PR DESCRIPTION
Removed redundant description of AI agents from the ai-agents.mdx guide. The removed sentence was explaining how AI agents automatically select data models, build queries, and present results, which is likely covered elsewhere in the guide.