### PR TITLE
docs: add env variables for AI verified answers

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -195,7 +195,9 @@ These variables enable you to configure the [AI Analyst functionality](/guides/a
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
 | `AI_COPILOT_ENABLED`               | Enables/Disables AI Analyst functionality                                                                                                |           | `false`  |
 | `ASK_AI_BUTTON_ENABLED`            | Enables the "Ask AI" button in the interface for direct access to AI agents, when disabled agents can be acessed from `/ai-agents` route |           | `false`  |
+| `AI_EMBEDDING_ENABLED`             | Enables AI embedding functionality for verified answers similarity matching                                                              |           | `false`  |
 | `AI_DEFAULT_PROVIDER`              | Default AI provider to use (`openai`, `azure`, `anthropic`, `openrouter`)                                                                |           | `openai` |
+| `AI_DEFAULT_EMBEDDING_PROVIDER`    | Default AI provider for embeddings (currently only `openai` supported). Falls back to `AI_DEFAULT_PROVIDER` if not set                   |           | `openai` |
 | `AI_COPILOT_DEBUG_LOGGING_ENABLED` | Enables debug logging for AI Copilot                                                                                                     |           | `false`  |
 | `AI_COPILOT_TELEMETRY_ENABLED`     | Enables telemetry for AI Copilot                                                                                                         |           | `false`  |
 | `AI_COPILOT_REQUIRES_FEATURE_FLAG` | Requires a feature flag to use AI Copilot                                                                                                |           | `false`  |
@@ -204,11 +206,12 @@ The AI Analyst supports multiple providers for flexibility. Choose one of the pr
 
 #### OpenAI Configuration
 
-| Variable            | Description                                 | Required?                  | Default   |
-| ------------------- | ------------------------------------------- | -------------------------- | --------- |
-| `OPENAI_API_KEY`    | API key for OpenAI                          | Required when using OpenAI |           |
-| `OPENAI_MODEL_NAME` | OpenAI model name to use                    |                            | `gpt-4.1` |
-| `OPENAI_BASE_URL`   | Optional base URL for OpenAI compatible API |                            |           |
+| Variable                     | Description                                 | Required?                  | Default                   |
+| ---------------------------- | ------------------------------------------- | -------------------------- | ------------------------- |
+| `OPENAI_API_KEY`             | API key for OpenAI                          | Required when using OpenAI |                           |
+| `OPENAI_MODEL_NAME`          | OpenAI model name to use                    |                            | `gpt-4.1`                 |
+| `OPENAI_EMBEDDING_MODEL`     | OpenAI embedding model for verified answers |                            | `text-embedding-3-small`  |
+| `OPENAI_BASE_URL`            | Optional base URL for OpenAI compatible API |                            |                           |
 
 #### Anthropic Configuration
 


### PR DESCRIPTION
# Add AI Embedding Configuration for Verified Answers Similarity Matching

This PR adds configuration options for AI embedding functionality, which enables verified answers similarity matching. The following environment variables have been added:

- `AI_EMBEDDING_ENABLED`: Controls whether AI embedding functionality is enabled (default: `false`)
- `AI_DEFAULT_EMBEDDING_PROVIDER`: Specifies the default AI provider for embeddings, falling back to `AI_DEFAULT_PROVIDER` if not set (currently only OpenAI is supported)
- `OPENAI_EMBEDDING_MODEL`: Specifies which OpenAI embedding model to use for verified answers (default: `text-embedding-3-small`)
