### PR TITLE
chore: rename JWT token(s) to JWT(s)

### DIFF
--- a/guides/embedding/charts.mdx
+++ b/guides/embedding/charts.mdx
@@ -88,7 +88,7 @@ function MyChart() {
 type ChartProps = {
   instanceUrl: string;                    // Required: Your Lightdash instance URL
   id: string;                             // Required: Chart UUID (savedQueryUuid)
-  token: string | Promise<string>;        // Required: JWT token
+  token: string | Promise<string>;        // Required: JWT
   styles?: {
     backgroundColor?: string;             // Chart background color or 'transparent'
     fontFamily?: string;                  // Font family for text
@@ -119,13 +119,13 @@ import Lightdash from '@lightdash/sdk';
 
 ## Configuring features
 
-Control what users can do with your embedded chart by configuring feature options. These options work for both iframe and React SDK embedding methods and are set in the JWT token.
+Control what users can do with your embedded chart by configuring feature options. These options work for both iframe and React SDK embedding methods and are set in the JWT.
 
 ### Export CSV
 
 Export CSV allows users to download the raw data behind the chart as a CSV file, useful for further analysis in spreadsheet applications.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -143,7 +143,7 @@ When enabled, users see a "Download CSV" option in the chart's menu.
 
 Export images allows users to download the chart visualization as a PNG image file, useful for presentations and reports.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -159,7 +159,7 @@ Export images allows users to download the chart visualization as a PNG image fi
 
 View underlying data shows users the raw data table behind the chart, making it easy to inspect the actual values and records that create the visualization.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -221,7 +221,7 @@ Users cannot:
 - View or edit SQL
 
 ### Scoped permissions
-The JWT token is scoped to the specific chart UUID in `contentId`. Users cannot:
+The JWT is scoped to the specific chart UUID in `contentId`. Users cannot:
 - Access other charts not in the token
 - View project configuration
 - Access explore metadata
@@ -335,7 +335,7 @@ Translate embedded charts using the `contentOverrides` prop. See [React SDK loca
   </Card>
 
   <Card title="Embedding API reference" icon="book" href="/references/embedding">
-    Complete JWT token structure documentation
+    Complete JWT structure documentation
   </Card>
 
   <Card title="React SDK reference" icon="react" href="/references/react-sdk">

--- a/guides/embedding/dashboards.mdx
+++ b/guides/embedding/dashboards.mdx
@@ -44,7 +44,7 @@ Alternatively, toggle "Allow all dashboards" to enable embedding for any dashboa
 
 ## Configuring interactivity
 
-Control what users can do with your embedded dashboard by configuring interactivity options. These options work for both iframe and React SDK embedding methods and are set in the JWT token.
+Control what users can do with your embedded dashboard by configuring interactivity options. These options work for both iframe and React SDK embedding methods and are set in the JWT.
 
 While the SDK options are configured via React props, iframe options are configured in the admin UI where you setup the embedding:
 
@@ -56,7 +56,7 @@ While the SDK options are configured via React props, iframe options are configu
 
 Dashboard filters allow users to slice and filter data across all charts in the dashboard. You can control whether users can interact with these filters, which filters they can modify, and whether the filter UI is visible.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -105,7 +105,7 @@ Dashboard filters allow users to slice and filter data across all charts in the 
 
 Parameters are dynamic values that can be referenced in your queries and filters. When enabled, users can modify parameter values to change what data is displayed across the dashboard.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -123,7 +123,7 @@ Parameters are dynamic values that can be referenced in your queries and filters
 
 Allow users to export data and visualizations from the embedded dashboard. You can control which export formats are available.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -146,7 +146,7 @@ Allow users to export data and visualizations from the embedded dashboard. You c
 
 Date zoom allows users to dynamically change the time granularity of time-series visualizations (e.g., view by day, week, month, quarter, year) without modifying the underlying query.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -162,7 +162,7 @@ Date zoom allows users to dynamically change the time granularity of time-series
 
 "Explore from here" allows users to navigate from a dashboard chart into the full query builder interface, where they can modify dimensions, metrics, filters, and create ad-hoc analyses starting from the chart's configuration.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -180,7 +180,7 @@ When enabled, users see an "Explore from here" option on chart tiles that opens 
 
 View underlying data shows users the raw data table behind any visualization, making it easy to inspect the actual values and records that create the chart.
 
-**Configure in JWT token:**
+**Configure in JWT:**
 
 ```javascript
 {
@@ -253,9 +253,9 @@ Or using dashboard slug:
 https://your-instance.lightdash.cloud/embed/{projectUuid}/dashboard/{dashboardSlug}#{jwtToken}
 ```
 
-The JWT token is passed in the URL hash fragment for security.
+The JWT is passed in the URL hash fragment for security.
 
-### Generate JWT token
+### Generate JWT
 
 <CodeGroup>
 
@@ -354,7 +354,7 @@ function MyDashboard() {
 ```typescript
 type DashboardProps = {
   instanceUrl: string;                    // Required: Your Lightdash instance URL
-  token: string | Promise<string>;        // Required: JWT token
+  token: string | Promise<string>;        // Required: JWT
   styles?: {
     backgroundColor?: string;             // Dashboard background color or 'transparent'
     fontFamily?: string;                  // Font family for text
@@ -453,6 +453,6 @@ Filter data based on the viewing user's properties. See the [user attributes ref
   </Card>
 
   <Card title="Embedding API reference" icon="book" href="/references/embedding">
-    Complete JWT token structure documentation
+    Complete JWT structure documentation
   </Card>
 </CardGroup>

--- a/guides/embedding/how-to-embed-content.mdx
+++ b/guides/embedding/how-to-embed-content.mdx
@@ -44,7 +44,7 @@ Chart embedding requires the React SDK. iframe embedding is only available for d
 
 Lightdash offers two embedding methods:
 
-**[iframe embedding](/references/iframe-embedding)**: Embed Lightdash **dashboards** using a simple iframe with a JWT token in the URL. No special integration required. iframe embedding is only available for dashboards, not charts.
+**[iframe embedding](/references/iframe-embedding)**: Embed Lightdash **dashboards** using a simple iframe with a JWT in the URL. No special integration required. iframe embedding is only available for dashboards, not charts.
 
 **[React SDK](/references/react-sdk)**: Use the `@lightdash/sdk` package for seamless integration in React applications. The React SDK supports both dashboards and charts with additional features like programmatic filters and callbacks.
 
@@ -88,7 +88,7 @@ Click on `Preview` to see how the embedded content will look, and click on `Gene
 
 ### Step 4: Generate tokens programmatically
 
-Although you can generate URLs directly from Lightdash with a long expiration, it is recommended to generate your own JWT tokens in your backend with a short expiration using your `secret` to make sure people can't be using embed URLs outside your app.
+Although you can generate URLs directly from Lightdash with a long expiration, it is recommended to generate your own JWTs in your backend with a short expiration using your `secret` to make sure people can't be using embed URLs outside your app.
 
 Lightdash provides code snippets you can copy and use in your app to generate valid embed URLs:
 
@@ -120,7 +120,7 @@ Lightdash provides code snippets you can copy and use in your app to generate va
   </Card>
 
   <Card title="Embedding API reference" icon="book" href="/references/embedding">
-    Complete JWT token structure and configuration options
+    Complete JWT structure and configuration options
   </Card>
 </CardGroup>
 

--- a/references/embedding.mdx
+++ b/references/embedding.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Embedding reference"
-description: "Complete API reference for embedding Lightdash content securely using JWT tokens"
+description: "Complete API reference for embedding Lightdash content securely using JWTs"
 ---
 
 import EmbedAvailability from '/snippets/embedding-availability.mdx';
@@ -9,7 +9,7 @@ import EmbedAvailability from '/snippets/embedding-availability.mdx';
 
 ## Overview
 
-This document provides complete API reference for JWT token structure and configuration options used by both embedding methods (iframe and React SDK).
+This document provides complete API reference for JWT structure and configuration options used by both embedding methods (iframe and React SDK).
 
 **For method-specific implementation details, see:**
 - [iframe embedding reference](/references/iframe-embedding) - URL patterns, HTML embedding
@@ -31,7 +31,7 @@ If you're interested in embedding and one or more of these items are blockers, p
 
 ## Embed secret
 
-The embed secret is used to generate JWT tokens for embedding content. This secret acts like a password that encrypts and signs your tokens.
+The embed secret is used to generate JWTs for embedding content. This secret acts like a password that encrypts and signs your tokens.
 
 <Frame>
   ![](/images/guides/embedding/embed-create-secret-fbb86d6bcb70f4d004c48adb3c107922.png)
@@ -43,9 +43,9 @@ Keep your embed secret secure! Store it as an environment variable and never exp
 
 You can regenerate the secret by clicking `Generate new secret`. If you do this, all previously generated embed URLs will be invalidated immediately.
 
-## JWT token structure
+## JWT structure
 
-All embedding methods use JWT tokens to authenticate and configure embedded content. The token structure includes three main parts:
+All embedding methods use JWTs to authenticate and configure embedded content. The token structure includes three main parts:
 
 ### Common fields
 
@@ -472,7 +472,7 @@ This metadata appears in [query tags](/references/workspace/usage-analytics#quer
 
 ## Token expiration
 
-JWT tokens should have short expiration times for security. Use your JWT library's expiration parameter:
+JWTs should have short expiration times for security. Use your JWT library's expiration parameter:
 
 ```javascript
 jwt.sign(payload, secret, { expiresIn: '1h' })

--- a/references/iframe-embedding.mdx
+++ b/references/iframe-embedding.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Embedding with iframe"
 sidebarTitle: "iframe"
-description: "Complete reference for embedding Lightdash content using iframes with JWT tokens in URL hash fragments"
+description: "Complete reference for embedding Lightdash content using iframes with JWTs in URL hash fragments"
 ---
 
 import EmbedAvailability from '/snippets/embedding-availability.mdx';
@@ -10,7 +10,7 @@ import EmbedAvailability from '/snippets/embedding-availability.mdx';
 
 ## Overview
 
-iframe embedding is the simplest way to embed Lightdash **dashboards** in your application. It requires no special libraries, dependencies, or CORS configuration—just generate a JWT token and construct an embed URL.
+iframe embedding is the simplest way to embed Lightdash **dashboards** in your application. It requires no special libraries, dependencies, or CORS configuration—just generate a JWT and construct an embed URL.
 
 <Warning>
 iframe embedding is **only available for dashboards**. Chart embedding requires the [React SDK](/references/react-sdk).
@@ -22,7 +22,7 @@ iframe embedding is **only available for dashboards**. Chart embedding requires 
 - **No dependencies** - No JavaScript libraries or SDK installation required
 - **No CORS configuration** - Unlike the React SDK, iframes don't require CORS setup
 - **Universal compatibility** - Works in any web environment (React, Vue, Angular, vanilla HTML)
-- **Secure** - JWT token in URL hash fragment isn't sent to server or logged
+- **Secure** - JWT in URL hash fragment isn't sent to server or logged
 
 ### When to use iframe embedding
 
@@ -40,13 +40,13 @@ Consider the [React SDK](/references/react-sdk) if you need:
 - Seamless React integration
 - TypeScript type definitions
 
-For JWT token structure and configuration options, see the [embedding reference](/references/embedding).
+For JWT structure and configuration options, see the [embedding reference](/references/embedding).
 
 ## iframe URL patterns
 
 All embed URLs follow this pattern: `https://your-instance.lightdash.cloud/embed/{projectUuid}/{contentType}/{contentId}#{jwtToken}`
 
-The JWT token is passed in the URL **hash fragment** (`#token`) for security—it's not sent to the server in requests or logged in browser history.
+The JWT is passed in the URL **hash fragment** (`#token`) for security—it's not sent to the server in requests or logged in browser history.
 
 ### Dashboard URL
 
@@ -66,7 +66,7 @@ https://app.lightdash.cloud/embed/abc-123-def-456/dashboard/my-sales-dashboard#e
 ```
 
 <Info>
-The JWT token in the hash fragment is NOT sent to the server with HTTP requests and does NOT appear in server logs or browser history, providing an additional security layer.
+The JWT in the hash fragment is NOT sent to the server with HTTP requests and does NOT appear in server logs or browser history, providing an additional security layer.
 </Info>
 
 <Warning>
@@ -79,7 +79,7 @@ The JWT token in the hash fragment is NOT sent to the server with HTTP requests 
 
 1. **Get your project UUID** - Found in Lightdash project settings
 2. **Get dashboard ID** - Dashboard UUID or slug
-3. **Generate JWT token** - See [embedding reference](/references/embedding#jwt-token-structure) for token structure
+3. **Generate JWT** - See [embedding reference](/references/embedding#jwt-token-structure) for token structure
 4. **Construct URL** - Combine parts with hash fragment
 
 <CodeGroup>
@@ -92,7 +92,7 @@ const instanceUrl = 'https://app.lightdash.cloud';
 const projectUuid = 'your-project-uuid';
 const dashboardUuid = 'your-dashboard-uuid';
 
-// Generate JWT token
+// Generate JWT
 const token = jwt.sign({
   content: {
     type: 'dashboard',
@@ -116,7 +116,7 @@ instance_url = 'https://app.lightdash.cloud'
 project_uuid = 'your-project-uuid'
 dashboard_uuid = 'your-dashboard-uuid'
 
-# Generate JWT token
+# Generate JWT
 payload = {
     'content': {
         'type': 'dashboard',
@@ -142,7 +142,7 @@ instance_url = 'https://app.lightdash.cloud'
 project_uuid = 'your-project-uuid'
 dashboard_uuid = 'your-dashboard-uuid'
 
-# Generate JWT token
+# Generate JWT
 payload = {
   content: {
     type: 'dashboard',
@@ -164,7 +164,7 @@ puts embed_url
 
 ### URL with user attributes
 
-For row-level security, include user attributes in the JWT token:
+For row-level security, include user attributes in the JWT:
 
 ```javascript
 const token = jwt.sign({
@@ -430,7 +430,7 @@ add_shortcode('lightdash', 'lightdash_embed_shortcode');
 
 ## Token refresh
 
-JWT tokens expire after the time specified in `expiresIn`. Handle token expiration:
+JWTs expire after the time specified in `expiresIn`. Handle token expiration:
 
 ### Option 1: Long-lived tokens
 
@@ -521,10 +521,10 @@ Then use:
 
 ### URL encoding issues
 
-**Issue:** JWT token or URL appears malformed
+**Issue:** JWT or URL appears malformed
 
 **Solutions:**
-- Don't URL-encode the JWT token in the hash fragment
+- Don't URL-encode the JWT in the hash fragment
 - If constructing URLs in templates, ensure proper escaping:
   ```html
   <!-- Good -->
@@ -539,7 +539,7 @@ Then use:
 **Issue:** Users can't interact with filters despite `dashboardFiltersInteractivity: { enabled: 'all' }`
 
 **Solutions:**
-- Verify JWT token includes correct interactivity settings
+- Verify JWT includes correct interactivity settings
 - Check browser console for JavaScript errors
 - Ensure iframe isn't using `sandbox` attribute without `allow-forms`
 
@@ -547,7 +547,7 @@ Then use:
 
 <CardGroup cols={2}>
   <Card title="Embedding reference" icon="book" href="/references/embedding">
-    JWT token structure and configuration options
+    JWT structure and configuration options
   </Card>
 
   <Card title="React SDK reference" icon="react" href="/references/react-sdk">

--- a/references/react-sdk.mdx
+++ b/references/react-sdk.mdx
@@ -98,7 +98,7 @@ Embed complete Lightdash dashboards with multiple visualizations, filters, and i
 type DashboardProps = {
   // Required
   instanceUrl: string;              // Your Lightdash instance URL
-  token: string | Promise<string>;  // JWT token (can be async)
+  token: string | Promise<string>;  // JWT (can be async)
 
   // Optional
   styles?: {
@@ -196,7 +196,7 @@ type ChartProps = {
   // Required
   instanceUrl: string;              // Your Lightdash instance URL
   id: string;                       // Chart UUID (savedQueryUuid)
-  token: string | Promise<string>;  // JWT token with type: 'chart'
+  token: string | Promise<string>;  // JWT with type: 'chart'
 
   // Optional
   styles?: {
@@ -243,7 +243,7 @@ function MyChart() {
 
 #### Token generation for charts
 
-Charts require a JWT token with `type: 'chart'`:
+Charts require a JWT with `type: 'chart'`:
 
 ```javascript
 // Backend API endpoint
@@ -274,7 +274,7 @@ Embed interactive data exploration interface with full query builder capabilitie
 type ExploreProps = {
   // Required
   instanceUrl: string;              // Your Lightdash instance URL
-  token: string | Promise<string>;  // JWT token with canExplore: true
+  token: string | Promise<string>;  // JWT with canExplore: true
 
   // Optional
   styles?: {
@@ -315,7 +315,7 @@ function MyExplore() {
 
 #### Token generation for explores
 
-Explores require `canExplore: true` in the JWT token:
+Explores require `canExplore: true` in the JWT:
 
 ```javascript
 // Backend API endpoint
@@ -336,7 +336,7 @@ export function generateExploreToken() {
 
 ## Generating embed tokens
 
-All SDK components require JWT tokens generated server-side. Here's a complete example:
+All SDK components require JWTs generated server-side. Here's a complete example:
 
 ### Backend API endpoint
 
@@ -401,7 +401,7 @@ function EmbeddedDashboard() {
 ```
 
 <Warning>
-  To ensure security, JWT token generation code must run **in your backend**, and the **Lightdash embed secret** must never be exposed in frontend code. This prevents unauthorized access and protects sensitive data.
+  To ensure security, JWT generation code must run **in your backend**, and the **Lightdash embed secret** must never be exposed in frontend code. This prevents unauthorized access and protects sensitive data.
 </Warning>
 
 ## Applying styles
@@ -473,7 +473,7 @@ Filtering is **only available for Dashboard** components. Chart and Explore comp
 </Info>
 
 <Warning>
-For the `filters` prop to work, your JWT token must have `dashboardFiltersInteractivity` set to `enabled: 'all'`. Without this configuration, filters will not be applied.
+For the `filters` prop to work, your JWT must have `dashboardFiltersInteractivity` set to `enabled: 'all'`. Without this configuration, filters will not be applied.
 </Warning>
 
 ### Filter structure
@@ -569,10 +569,10 @@ Available operators:
 
 ### Available fields
 
-Only fields that are available for filtering can be filtered. These are specified in the JWT token passed to the SDK.
+Only fields that are available for filtering can be filtered. These are specified in the JWT passed to the SDK.
 
 <Info>
-To generate tokens with filterable fields, configure your embed in the Lightdash UI or include the appropriate fields in your JWT token structure.
+To generate tokens with filterable fields, configure your embed in the Lightdash UI or include the appropriate fields in your JWT structure.
 </Info>
 
 ## Localization
@@ -789,7 +789,7 @@ export function EmbeddedDashboard() {
   </Card>
 
   <Card title="Embedding API reference" icon="book" href="/references/embedding">
-    Complete JWT token structure and configuration
+    Complete JWT structure and configuration
   </Card>
 
   <Card title="iframe embedding reference" icon="code" href="/references/iframe-embedding">


### PR DESCRIPTION
Just a small pedantic renaming of "JWT token(s)" to "JWT(s)". JWT stands for JSON Web Token, so adding another token is the same mistake as saying "ATM machine".

https://en.wikipedia.org/wiki/JSON_Web_Token