### PR TITLE
Add reference to new `HEADWAY_ENABLED` env variable

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -50,6 +50,7 @@ This is a reference to all environment variables that can be used to configure a
 | `USE_SECURE_BROWSER`                         | Use secure WebSocket connections for headless browser (default=false)                                                                                                                                                                            |
 | `DISABLE_DASHBOARD_COMMENTS`                 | Disables dashboard comments (default=false)                                                                                                                                                                                                      |
 | `ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED` | Enables organization warehouse settings (default=false)                                                                                                                                                                                          |
+| `HEADWAY_ENABLED`                            | Enables the Headway changelogs widget in the Lightdash menu (default=true)                                                                                                                                                              |
 
 Lightdash also accepts all [standard postgres environment variables](https://www.postgresql.org/docs/9.3/libpq-envars.html)
 


### PR DESCRIPTION
Adding the new environment variable to control whether headway is enabled or not.

It was introduced here: https://github.com/lightdash/lightdash/pull/19299

<img width="920" height="164" alt="image" src="https://github.com/user-attachments/assets/80f76c13-bd4d-4194-ad4e-734133113b7b" />
