### PR TITLE
docs: remove email/password login option from CLI authentication

### DIFF
--- a/guides/cli/cli-authentication.mdx
+++ b/guides/cli/cli-authentication.mdx
@@ -65,16 +65,6 @@ lightdash login
 This uses your previously saved instance URL.
 
 <AccordionGroup>
-  <Accordion title="Login with email and password">
-    If you prefer to use email and password instead of browser-based OAuth:
-
-    ```bash
-    lightdash login your_subdomain_here --no-oauth
-    ```
-
-    You'll be prompted to enter your email and password.
-  </Accordion>
-
   <Accordion title="Login with a personal access token (for SSO users)">
     If you use single sign-on (SSO) in the browser, login with a personal access token.
 


### PR DESCRIPTION
Remove deprecated email/password cli authentication method

Context: https://lightdash.slack.com/archives/C08L4N6GU1J/p1769006534584019