### PR TITLE
Add CLI documentation for config list-projects and get-project commands

### DIFF
--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -92,6 +92,8 @@ For examples and command-specific options, click through the command in the tabl
 | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 |[`lightdash login`](/references/lightdash-cli#lightdash-login)                           | Log in to a Lightdash instance using email/password or a token                     |
 |[`lightdash config set-project`](/references/lightdash-cli#lightdash-config-set-project) | Choose or set the Lightdash project you are working on                             |
+|[`lightdash config get-project`](/references/lightdash-cli#lightdash-config-get-project) | Get the current active project                                                     |
+|[`lightdash config list-projects`](/references/lightdash-cli#lightdash-config-list-projects) | List all non-preview projects in your organization                             |
 |[`lightdash compile`](/references/lightdash-cli#lightdash-compile)                       | Compile lightdash resources using your local project files                         |
 |[`lightdash preview`](/references/lightdash-cli#lightdash-preview)                       | Create a temporary preview project, then wait for a keypress to stop               |
 |[`lightdash start-preview`](/references/lightdash-cli#lightdash-start-preview)           | Create a preview project that stays open until it is stopped                       |

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -188,6 +188,26 @@ Set project to the one with this UUID:
 lightdash config set-project --uuid "d75379bc-f6e9-4e52-86b2-d897cabacd0c"
 ```
 
+### `lightdash config get-project`
+
+Get the current active project that the CLI is configured to use.
+
+```bash
+lightdash config get-project
+```
+
+This command displays the project that is currently set for CLI operations. Use this to verify which project will be affected by commands like `lightdash validate`, `lightdash preview`, and `lightdash deploy`.
+
+### `lightdash config list-projects`
+
+List all non-preview projects in your organization.
+
+```bash
+lightdash config list-projects
+```
+
+This command displays all available projects (excluding preview projects) that you can select using `lightdash config set-project`.
+
 ### `lightdash compile`
 
 Compile Lightdash resources using your local project and database credentials. dbt gets compiled first, then your Lightdash explores. If you use [dbt node selection](#dbt-node-selection) to only compile a subset of models, Lightdash will also compile models joined to those models to ensure no field references are broken.


### PR DESCRIPTION
Added documentation for two new CLI commands: `lightdash config list-projects` to list all non-preview projects and `lightdash config get-project` to get the current active project. These commands complement the existing `lightdash config set-project` command for better project management workflow.

Files changed:
- references/lightdash-cli.mdx

---

Created by Mintlify agent