### PR TITLE
Add Jupyter notebook example link to Python SDK docs

### DIFF
--- a/sdk/python-sdk.mdx
+++ b/sdk/python-sdk.mdx
@@ -5,6 +5,10 @@ description: "Query your semantic layer with native Python syntax."
 
 The Lightdash Python SDK lets you query your semantic layer directly from Python. Use it in Jupyter notebooks, Python scripts, or anywhere you use Python to ensure everyone pulls from a single source of truth.
 
+<Card title="See it in action" icon="notebook" href="https://github.com/lightdash/python-sdk/blob/main/examples/getting_started.ipynb">
+  Try the getting started Jupyter notebook for a hands-on walkthrough.
+</Card>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Added a card near the top of the Python SDK documentation that links to the example Jupyter notebook in the python-sdk repository. This provides users with a quick way to see the SDK in action through a practical example.

Files changed:
- sdk/python-sdk.mdx

---

Created by Mintlify agent