### PR TITLE
Clarify caching behavior based on support ticket patterns

### DIFF
--- a/guides/developer/caching.mdx
+++ b/guides/developer/caching.mdx
@@ -14,6 +14,10 @@ Lightdash supports two types of caching:
 1. **[Cached Filter values](#filter-value-caching)** - enabled for every cloud user without requiring any configuration.
 2. **[Cached results for Charts and Dashboards](#chart-and-dashboard-results-caching)** - only available for Cloud Pro or above and must be enabled by the Lightdash team.
 
+<Note>
+  Results caching is **not enabled by default**, even on paid plans. To check if caching is active on your instance, look for a cache timestamp in the dashboard header — if no time is displayed, caching is not enabled. Contact the Lightdash team to enable it.
+</Note>
+
 ## Filter value caching
 
 This type of caching works without any configuration for cloud users. You'll see a message in your filter values that tells you when the cached filter values were loaded from (usually within the last day). If you want to refresh the filter values, you can click on that message and the values will be refreshed.
@@ -32,15 +36,18 @@ Caching popular charts and dashboards will reduce warehouse costs to the organiz
 
 ### Scope of the cache
 
+When caching is enabled, it applies to your **entire Lightdash instance**. There is currently no way to enable caching for specific projects or individual dashboards — it's all or nothing.
+
 These Lightdash features use caching (if it's enabled on your instance):
 
 - **Saved Charts** are cached based on the last refresh in any context (edit mode, view mode, dashboard refresh, etc.), but queries made while editing are NOT cached or pulled from cache.
-- **Dashboard tiles** (internal and embedded) will use the cache from saved charts they reference. If charts only exist on a single dashboard, they will refresh whebnever you click the Refresh button on the dashboard.
+- **Dashboard tiles** (internal and embedded) will use the cache from saved charts they reference. If charts only exist on a single dashboard, they will refresh whenever you click the Refresh button on the dashboard.
 - **Scheduled Deliveries** generate and use cached results for the saved chart or dashboard they belong to.
+- **Google Sheets syncs** also use cached results. If you need syncs to always return fresh data, be aware that enabling caching will cause syncs to deliver cached results until the cache expires.
 
 These Lightdash features DO NOT use caching:
 
-- **Creating a new query from tables or editing a saved chart** are NOT cached because they are typically one-off explorations that don’t benefit from caching.
+- **Creating a new query from tables or editing a saved chart** are NOT cached because they are typically one-off explorations that don't benefit from caching.
 - **Metrics Catalog and Spotlight** do not use caching yet, but likely will in the future.
 - **Charts built in SQL runner** do not use caching.
 
@@ -72,7 +79,13 @@ This ensures your queries can leverage cached results and reduce warehouse load.
 
 ### Cache Expiry and Invalidation
 
-Cached results automatically expire after 24 hours. The expiry time is configurable at the organization level, but you'll need to reach out to the Lightdash team.
+Cached results automatically expire after 24 hours by default. The expiry time is configurable at the organization level, but you'll need to reach out to the Lightdash team.
+
+Cache expiry is **rolling, not scheduled** — it's based on the age of each cached result, not a fixed time of day. For example, if a dashboard is first loaded at 2:00 PM, its cache expires at 2:00 PM the next day. This means different dashboards and charts may have different cache ages depending on when they were last refreshed.
+
+<Tip>
+If your dashboards report on "yesterday's data" and you want users to always see fresh results in the morning, consider setting a shorter cache duration (e.g., 8 hours) so that results cached during the workday expire overnight. Contact the Lightdash team to adjust your cache duration.
+</Tip>
 
 The dashboard header displays the date and time of the chart with the oldest cache. If no time is displayed, then no charts are cached. You can invalidate and refresh cached dashboard results by pressing the dashboard refresh button.
 

--- a/guides/developer/caching.mdx
+++ b/guides/developer/caching.mdx
@@ -15,7 +15,7 @@ Lightdash supports two types of caching:
 2. **[Cached results for Charts and Dashboards](#chart-and-dashboard-results-caching)** - only available for Cloud Pro or above and must be enabled by the Lightdash team.
 
 <Note>
-  Results caching is **not enabled by default**, even on paid plans. To check if caching is active on your instance, look for a cache timestamp in the dashboard header — if no time is displayed, caching is not enabled. Contact the Lightdash team to enable it.
+  Results caching is **not enabled by default**, even on paid plans. To check if caching is active on your instance, look for a cache timestamp in the dashboard header. If no time is displayed, caching is not enabled. Contact the Lightdash team to enable it.
 </Note>
 
 ## Filter value caching
@@ -36,7 +36,7 @@ Caching popular charts and dashboards will reduce warehouse costs to the organiz
 
 ### Scope of the cache
 
-When caching is enabled, it applies to your **entire Lightdash instance**. There is currently no way to enable caching for specific projects or individual dashboards — it's all or nothing.
+When caching is enabled, it applies to your **entire Lightdash instance**. There is currently no way to enable caching for specific projects or individual dashboards. It's all or nothing.
 
 These Lightdash features use caching (if it's enabled on your instance):
 
@@ -81,7 +81,7 @@ This ensures your queries can leverage cached results and reduce warehouse load.
 
 Cached results automatically expire after 24 hours by default. The expiry time is configurable at the organization level, but you'll need to reach out to the Lightdash team.
 
-Cache expiry is **rolling, not scheduled** — it's based on the age of each cached result, not a fixed time of day. For example, if a dashboard is first loaded at 2:00 PM, its cache expires at 2:00 PM the next day. This means different dashboards and charts may have different cache ages depending on when they were last refreshed.
+Cache expiry is **rolling, not scheduled**. It's based on the age of each cached result, not a fixed time of day. For example, if a dashboard is first loaded at 2:00 PM, its cache expires at 2:00 PM the next day. This means different dashboards and charts may have different cache ages depending on when they were last refreshed.
 
 <Tip>
 If your dashboards report on "yesterday's data" and you want users to always see fresh results in the morning, consider setting a shorter cache duration (e.g., 8 hours) so that results cached during the workday expire overnight. Contact the Lightdash team to adjust your cache duration.


### PR DESCRIPTION
## Summary
- Adds a note that results caching is **not enabled by default**, even on paid plans, with guidance on how to check
- Clarifies that caching applies **instance-wide** (not per-project or per-dashboard)
- Adds that **Google Sheets syncs** also use cached results (missing from the original list)
- Explains that cache expiry is **rolling, not scheduled** — based on age since last refresh, not a fixed daily time
- Adds a tip for teams reporting on "yesterday's data" to use shorter cache durations
- Fixes a typo ("whebnever" → "whenever")

## Context
These clarifications are based on recurring patterns in closed support tickets over the past 4 months (Oct 2025 – Feb 2026), where customers repeatedly asked questions that could have been answered by clearer docs:
- Customers asking "is caching enabled for us?" with no way to self-check
- A customer whose Google Sheets syncs started delivering stale data after caching was enabled
- A customer confused about why their "yesterday's data" dashboards showed old numbers until mid-afternoon

## Test plan
- [x] Verify the page renders correctly in Mintlify preview
- [x] Confirm the Note, Tip, and formatting display properly