### PR TITLE
docs: add MCP domain allowlisting requirements

### DIFF
--- a/references/integrations/lightdash-mcp.mdx
+++ b/references/integrations/lightdash-mcp.mdx
@@ -38,6 +38,23 @@ Setting up MCP is quick and straightforward. You can connect your AI assistant t
 - A Lightdash Cloud Pro or Enterprise account with MCP enabled
 - An MCP-compatible AI assistant (e.g., Claude.ai, Claude Desktop, ChatGPT)
 
+### Network requirements
+
+If your organization uses a corporate firewall, VPN, or internet security tool, the following domains must be allowlisted for MCP to work correctly:
+
+| Domain | Purpose |
+|---|---|
+| `<your_instance_name>.lightdash.cloud` | Lightdash API and OAuth authentication |
+| `claudemcpcontent.com` | Used by Claude to render visual content (charts, tables) from MCP connectors |
+
+<Warning>
+  If `claudemcpcontent.com` is blocked, Claude will still return query results as text but will not be able to display Lightdash visual charts. You may see the error: _"Failed to set up MCP app. Check that claudemcpcontent.com is not blocked by your network or browser."_
+</Warning>
+
+<Tip>
+  If you're having trouble, try opening Claude in an incognito/private browser window to rule out browser extensions (like ad blockers) that may be blocking these domains.
+</Tip>
+
 ### Installation
 
 #### Claude.ai (Web & Desktop Apps)
@@ -380,3 +397,7 @@ A: Yes, each team member can set up their own MCP connection with their individu
 **Q: Can MCP modify my data or dashboards?**
 
 A: No, MCP has read-only access. It can search and explore your data models but cannot make any modifications to your Lightdash configuration or underlying data.
+
+**Q: Claude returns data as text but no visual chart is displayed. What's wrong?**
+
+A: Claude uses the domain `claudemcpcontent.com` to render visual content from MCP connectors. If this domain is blocked by your corporate firewall, VPN, internet security tool, or a browser extension (like an ad blocker), Claude will fall back to text-only output. See [Network requirements](#network-requirements) above for the full list of domains to allowlist.


### PR DESCRIPTION
## Summary
- Adds a **Network requirements** section to the MCP setup docs, documenting that `claudemcpcontent.com` and the Lightdash instance domain must be allowlisted on corporate networks
- Adds a new FAQ entry for the "text-only output, no visual charts" issue
- Addresses [AE-215](https://linear.app/lightdash/issue/AE-215/docs-mcp-setup-domain-allowlisting-requirements) based on recurring support ticket [#10763](https://app.usepylon.com/issues?issueNumber=10763)

## Context
A customer setting up MCP in Claude couldn't get visual chart rendering because their internet security tool was blocking `claudemcpcontent.com`. The MCP connection itself worked fine (data returned as text), but the visual output requires this Anthropic-owned domain. This wasn't documented anywhere.

## Test plan
- [x] Verify the new section renders correctly on the Mintlify docs preview
- [x] Confirm the anchor link `#network-requirements` works from the FAQ entry