### PR TITLE
Add level of detail metrics example

### DIFF
--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1898,31 +1898,31 @@ Here's an example: imagine you wanted to calculate the average cost per item tha
 
 Sometimes you need to calculate a percentage or ratio where the numerator and denominator require different levels of aggregation. This is commonly known as a "level of detail" calculation.
 
-{/* TODO: Add link to live demo dashboard */}
-
-<Frame>
-  ![](/images/references/lod-metrics-example.png)
-</Frame>
+_Coming to the [demo site](https://analytics.lightdash.cloud) soon._
 
 ### The problem
 
 Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals, broken down by deal plan?"**
 
-You have two tables:
+You have an `accounts` table with 152 Enterprise accounts and a `deals` table that is sparse (not every account has deals in every plan). When you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped. It only counts accounts that have deals in that specific plan, not all accounts in the segment.
 
-| **accounts** | | **deals** (sparse) | | |
+**Without the workaround (wrong results):**
+
+| Segment | Plan | Accounts with Won Deals | Total Accounts | % |
 |---|---|---|---|---|
-| segment | total accounts | plan | segment | accounts with won deals |
-| Enterprise | 152 | Basic | Enterprise | 36 |
-| Midmarket | 293 | Professional | Enterprise | 13 |
-| SMB | 560 | Basic | Midmarket | 73 |
-| | | Professional | Midmarket | 27 |
-| | | Basic | SMB | 138 |
-| | | Professional | SMB | 54 |
+| Enterprise | Basic | 36 | 107 | 33.6% |
+| Enterprise | Professional | 13 | 46 | 28.3% |
 
-The denominator (total accounts per segment) should be **152** for Enterprise regardless of which plan you're looking at. But when you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped. It only counts accounts that have deals with that specific plan, not all accounts in the segment.
+The total accounts column shows **107** and **46** instead of the true total of **152**. This is because the join to deals filters out accounts that don't have deals in that plan.
 
-This produces wrong results: `36/107 = 33.6%` instead of the correct `36/152 = 23.7%`.
+**With the workaround (correct results):**
+
+| Segment | Plan | Accounts with Won Deals | Total Accounts | % |
+|---|---|---|---|---|
+| Enterprise | Basic | 36 | 152 | 23.7% |
+| Enterprise | Professional | 13 | 152 | 8.6% |
+
+The total accounts column correctly stays at **152** regardless of which plan you're looking at. This is achieved by pre-computing the denominator in a separate CTE in your dbt model.
 
 ### The workaround
 

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1896,15 +1896,19 @@ Here's an example: imagine you wanted to calculate the average cost per item tha
 
 ## Level of detail metrics
 
-Sometimes you need to calculate a percentage or ratio where the numerator and denominator require different levels of aggregation. This is commonly known as a "level of detail" calculation.
+When you build a query in Lightdash, every metric in the results is grouped by the dimensions you've selected. This is usually what you want, but sometimes you need a metric to be calculated at a different granularity than the rest of the query. For example, you might want a denominator that stays at a coarser grain even when you add more dimensions to the view.
+
+This is commonly known as a "level of detail" (LOD) calculation. The idea is that certain metrics should _ignore_ specific dimensions during aggregation, so their values remain stable regardless of how the data is sliced.
 
 _Coming to the [demo site](https://demo.lightdash.com/projects/d496d901-a76d-4916-9eae-b81bc7337013/home) soon._
 
 ### The problem
 
-Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals, broken down by deal plan?"**
+This comes up most often with percentage or ratio metrics. Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals?"** and you want to break this down by deal plan.
 
-You have an `accounts` table with 152 Enterprise accounts and a `deals` table that is sparse (not every account has deals in every plan). When you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped. It only counts accounts that have deals in that specific plan, not all accounts in the segment.
+The numerator (accounts with Won deals) should naturally vary by plan. But the denominator (total accounts in the segment) should not -- there are 152 Enterprise accounts regardless of which plan you're analyzing.
+
+When you join accounts to deals and group by both segment and plan, the denominator gets scoped to only the accounts that have deals in that plan. This is the default behavior in any BI tool that uses a join-then-group approach.
 
 **Without level of detail (denominator grouped by plan):**
 
@@ -1913,7 +1917,7 @@ You have an `accounts` table with 152 Enterprise accounts and a `deals` table th
 | Enterprise | Basic | 36 | 107 | 33.6% |
 | Enterprise | Professional | 13 | 46 | 28.3% |
 
-Here, the total accounts column shows **107** and **46** because the denominator is scoped to accounts that have deals in that specific plan.
+The total accounts column shows **107** and **46** because only accounts that have deals in that specific plan are included in the count.
 
 **With level of detail (denominator independent of plan):**
 
@@ -1922,7 +1926,7 @@ Here, the total accounts column shows **107** and **46** because the denominator
 | Enterprise | Basic | 36 | 152 | 23.7% |
 | Enterprise | Professional | 13 | 152 | 8.6% |
 
-The total accounts column correctly stays at **152** regardless of which plan you're looking at. This is achieved by pre-computing the denominator in a separate CTE in your dbt model.
+The total accounts column stays at **152** because the denominator is computed independently of the plan dimension. This is achieved by pre-computing the denominator in a separate CTE in your dbt model.
 
 ### The workaround
 

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1906,7 +1906,7 @@ _Coming to the [demo site](https://demo.lightdash.com/projects/d496d901-a76d-491
 
 This comes up most often with percentage or ratio metrics. Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals?"** and you want to break this down by deal plan.
 
-The numerator (accounts with Won deals) should naturally vary by plan. But the denominator (total accounts in the segment) should not -- there are 152 Enterprise accounts regardless of which plan you're analyzing.
+The numerator (accounts with Won deals) should naturally vary by plan. But the denominator (total accounts in the segment) should not. There are 152 Enterprise accounts regardless of which plan you're analyzing.
 
 When you join accounts to deals and group by both segment and plan, the denominator gets scoped to only the accounts that have deals in that plan. This is the default behavior in any BI tool that uses a join-then-group approach.
 

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1893,3 +1893,110 @@ Here's an example: imagine you wanted to calculate the average cost per item tha
     ```
   </Tab>
 </Tabs>
+
+## Level of detail metrics
+
+Sometimes you need to calculate a percentage or ratio where the numerator and denominator require different levels of aggregation. This is commonly known as a "level of detail" calculation.
+
+### The problem
+
+Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals, broken down by deal plan?"**
+
+You have two tables:
+
+| **accounts** | | **deals** (sparse) | | |
+|---|---|---|---|---|
+| segment | total accounts | plan | segment | accounts with won deals |
+| Enterprise | 152 | Basic | Enterprise | 36 |
+| Midmarket | 293 | Professional | Enterprise | 13 |
+| SMB | 560 | Basic | Midmarket | 73 |
+| | | Professional | Midmarket | 27 |
+| | | Basic | SMB | 138 |
+| | | Professional | SMB | 54 |
+
+The denominator (total accounts per segment) should be **152** for Enterprise regardless of which plan you're looking at. But when you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped — it only counts accounts that have deals with that specific plan, not all accounts in the segment.
+
+This produces wrong results: `36/107 = 33.6%` instead of the correct `36/152 = 23.7%`.
+
+### The workaround
+
+The solution is to pre-compute the coarser-grain metric (total accounts per segment) in your dbt model, so it's always correct regardless of which dimensions are selected in Lightdash.
+
+**Step 1: Pre-compute the denominator in your dbt model**
+
+```sql
+with segment_totals as (
+    select
+        segment,
+        count(distinct account_id) as total_accounts_in_segment
+    from {{ ref('accounts') }}
+    group by segment
+),
+
+account_deals as (
+    select
+        a.account_id,
+        a.segment,
+        d.deal_id,
+        d.plan,
+        d.stage
+    from {{ ref('accounts') }} a
+    inner join {{ ref('deals') }} d on a.account_id = d.account_id
+)
+
+select
+    ad.*,
+    st.total_accounts_in_segment
+from account_deals ad
+left join segment_totals st on ad.segment = st.segment
+```
+
+**Step 2: Define the metrics in your YAML**
+
+<Tabs>
+  <Tab title="dbt v1.9 and earlier">
+    ```yaml
+    models:
+      - name: account_deal_metrics
+        meta:
+          metrics:
+            pct_accounts_with_won_deals:
+              type: number
+              label: "% Accounts with Won Deals"
+              format: percent
+              sql: ${unique_accounts_with_won_deals} / NULLIF(${segment_total_accounts}, 0)
+        columns:
+          - name: account_id
+            meta:
+              dimension:
+                type: string
+                hidden: true
+              metrics:
+                unique_accounts_with_won_deals:
+                  type: count_distinct
+                  filters:
+                    - stage: 'Won'
+          - name: segment
+            meta:
+              dimension:
+                type: string
+          - name: plan
+            meta:
+              dimension:
+                type: string
+          - name: total_accounts_in_segment
+            meta:
+              dimension:
+                type: number
+              metrics:
+                segment_total_accounts:
+                  type: max
+    ```
+  </Tab>
+</Tabs>
+
+The key insight is that `total_accounts_in_segment` is pre-computed in the SQL and is the same value for every row in a segment. Using `max` as the aggregation returns the correct segment-level total, regardless of what other dimensions (like `plan`) are in the query.
+
+The `pct_accounts_with_won_deals` metric then divides the numerator (which correctly varies by plan) by the denominator (which stays fixed per segment).
+
+{/* TODO: Add link to live demo */}

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1906,16 +1906,16 @@ Consider this scenario: you want to calculate **"what % of accounts in each segm
 
 You have an `accounts` table with 152 Enterprise accounts and a `deals` table that is sparse (not every account has deals in every plan). When you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped. It only counts accounts that have deals in that specific plan, not all accounts in the segment.
 
-**Without the workaround (wrong results):**
+**Without level of detail (denominator grouped by plan):**
 
 | Segment | Plan | Accounts with Won Deals | Total Accounts | % |
 |---|---|---|---|---|
 | Enterprise | Basic | 36 | 107 | 33.6% |
 | Enterprise | Professional | 13 | 46 | 28.3% |
 
-The total accounts column shows **107** and **46** instead of the true total of **152**. This is because the join to deals filters out accounts that don't have deals in that plan.
+Here, the total accounts column shows **107** and **46** because the denominator is scoped to accounts that have deals in that specific plan.
 
-**With the workaround (correct results):**
+**With level of detail (denominator independent of plan):**
 
 | Segment | Plan | Accounts with Won Deals | Total Accounts | % |
 |---|---|---|---|---|

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1898,6 +1898,12 @@ Here's an example: imagine you wanted to calculate the average cost per item tha
 
 Sometimes you need to calculate a percentage or ratio where the numerator and denominator require different levels of aggregation. This is commonly known as a "level of detail" calculation.
 
+{/* TODO: Add link to live demo dashboard */}
+
+<Frame>
+  ![](/images/references/lod-metrics-example.png)
+</Frame>
+
 ### The problem
 
 Consider this scenario: you want to calculate **"what % of accounts in each segment have Won deals, broken down by deal plan?"**
@@ -1914,16 +1920,17 @@ You have two tables:
 | | | Basic | SMB | 138 |
 | | | Professional | SMB | 54 |
 
-The denominator (total accounts per segment) should be **152** for Enterprise regardless of which plan you're looking at. But when you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped — it only counts accounts that have deals with that specific plan, not all accounts in the segment.
+The denominator (total accounts per segment) should be **152** for Enterprise regardless of which plan you're looking at. But when you join accounts to deals and group by both segment and plan, the denominator gets incorrectly scoped. It only counts accounts that have deals with that specific plan, not all accounts in the segment.
 
 This produces wrong results: `36/107 = 33.6%` instead of the correct `36/152 = 23.7%`.
 
 ### The workaround
 
-The solution is to pre-compute the coarser-grain metric (total accounts per segment) in your dbt model, so it's always correct regardless of which dimensions are selected in Lightdash.
+The solution is to pre-compute the coarser-grain metric (total accounts per segment) in your dbt model, so it is always correct regardless of which dimensions are selected in Lightdash.
 
 **Step 1: Pre-compute the denominator in your dbt model**
 
+<Accordion title="SQL model">
 ```sql
 with segment_totals as (
     select
@@ -1950,6 +1957,7 @@ select
 from account_deals ad
 left join segment_totals st on ad.segment = st.segment
 ```
+</Accordion>
 
 **Step 2: Define the metrics in your YAML**
 
@@ -1993,10 +2001,84 @@ left join segment_totals st on ad.segment = st.segment
                   type: max
     ```
   </Tab>
+  <Tab title="dbt v1.10+ and Fusion">
+    ```yaml
+    models:
+      - name: account_deal_metrics
+        config:
+          meta:
+            metrics:
+              pct_accounts_with_won_deals:
+                type: number
+                label: "% Accounts with Won Deals"
+                format: percent
+                sql: ${unique_accounts_with_won_deals} / NULLIF(${segment_total_accounts}, 0)
+        columns:
+          - name: account_id
+            config:
+              meta:
+                dimension:
+                  type: string
+                  hidden: true
+                metrics:
+                  unique_accounts_with_won_deals:
+                    type: count_distinct
+                    filters:
+                      - stage: 'Won'
+          - name: segment
+            config:
+              meta:
+                dimension:
+                  type: string
+          - name: plan
+            config:
+              meta:
+                dimension:
+                  type: string
+          - name: total_accounts_in_segment
+            config:
+              meta:
+                dimension:
+                  type: number
+                metrics:
+                  segment_total_accounts:
+                    type: max
+    ```
+  </Tab>
+  <Tab title="Lightdash YAML">
+    ```yaml
+    type: model
+    name: account_deal_metrics
+
+    dimensions:
+      - name: account_id
+        type: string
+        hidden: true
+      - name: segment
+        type: string
+      - name: plan
+        type: string
+      - name: total_accounts_in_segment
+        type: number
+
+    metrics:
+      unique_accounts_with_won_deals:
+        type: count_distinct
+        sql: ${TABLE}.account_id
+        filters:
+          - stage: 'Won'
+      segment_total_accounts:
+        type: max
+        sql: ${TABLE}.total_accounts_in_segment
+      pct_accounts_with_won_deals:
+        type: number
+        label: "% Accounts with Won Deals"
+        format: percent
+        sql: ${unique_accounts_with_won_deals} / NULLIF(${segment_total_accounts}, 0)
+    ```
+  </Tab>
 </Tabs>
 
 The key insight is that `total_accounts_in_segment` is pre-computed in the SQL and is the same value for every row in a segment. Using `max` as the aggregation returns the correct segment-level total, regardless of what other dimensions (like `plan`) are in the query.
 
 The `pct_accounts_with_won_deals` metric then divides the numerator (which correctly varies by plan) by the denominator (which stays fixed per segment).
-
-{/* TODO: Add link to live demo */}

--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -1898,7 +1898,7 @@ Here's an example: imagine you wanted to calculate the average cost per item tha
 
 Sometimes you need to calculate a percentage or ratio where the numerator and denominator require different levels of aggregation. This is commonly known as a "level of detail" calculation.
 
-_Coming to the [demo site](https://analytics.lightdash.cloud) soon._
+_Coming to the [demo site](https://demo.lightdash.com/projects/d496d901-a76d-4916-9eae-b81bc7337013/home) soon._
 
 ### The problem
 


### PR DESCRIPTION
## Summary
- Adds a new "Level of detail metrics" section to the metrics reference page
- Explains the problem: percentage metrics where numerator and denominator need different aggregation levels
- Shows the workaround: pre-computing the coarser-grain metric in dbt
- Includes SQL and YAML code examples
- Has a TODO placeholder for linking to the live demo once deployed

## Test plan
- [ ] Preview the docs page to verify formatting renders correctly
- [ ] Verify code blocks display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)