### PR TITLE
Add LiteLLM / OpenAI-compatible proxy docs

### DIFF
--- a/references/tables.mdx
+++ b/references/tables.mdx
@@ -654,7 +654,7 @@ Below you can see there is a default filter with the optional required flag, tha
 </Tabs>
 
 <Info>
-  Note: Required filters are not a security feature. For secure data access control, use [user attributes](/references/user-attributes).
+  Note: Required filters are not a security feature. For secure data access control, use [user attributes](/references/workspace/user-attributes).
 </Info>
 
 ### If you have many filters in your list, they will be joined using `AND`

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -253,6 +253,21 @@ To enable AI Analyst, set `AI_COPILOT_ENABLED=true` and provide an API key for `
 | `OPENAI_BASE_URL`         | Optional base URL for OpenAI compatible API                                                 |
 | `OPENAI_AVAILABLE_MODELS` | Comma-separated list of models available in the model picker (default=All supported models) |
 
+<Tip>
+**Using an OpenAI-compatible proxy (e.g. LiteLLM)**
+
+If your organization uses an OpenAI-compatible proxy like [LiteLLM](https://www.litellm.ai/), you can connect it to Lightdash by setting `AI_DEFAULT_PROVIDER=openai` and pointing `OPENAI_BASE_URL` to your proxy URL. For example:
+
+- `AI_DEFAULT_PROVIDER=openai`
+- `OPENAI_API_KEY=<your-proxy-api-key>`
+- `OPENAI_BASE_URL=<your-proxy-url>`
+- `OPENAI_MODEL_NAME=<model-name-configured-in-your-proxy>`
+
+Make sure your proxy has the model names correctly mapped. For example, if you set `OPENAI_MODEL_NAME=gpt-4o`, your proxy needs to have that model routed to whatever underlying provider you're using. The same applies for the embedding model.
+
+If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_MODELS` with a comma-separated list of model names.
+</Tip>
+
 #### Anthropic Configuration
 
 | Variable                     | Description                                                                                 |


### PR DESCRIPTION
## Summary
- Adds a tip under the OpenAI Configuration section documenting how to use OpenAI-compatible proxies (like LiteLLM) with Lightdash AI Analyst
- Covers required env vars (`AI_DEFAULT_PROVIDER`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL_NAME`) and model mapping caveats

## Context
Multiple customers have asked about LiteLLM support (Pylon #10882). Since LiteLLM exposes an OpenAI-compatible API, it works via the existing `OPENAI_BASE_URL` config — but this wasn't documented.

## Test plan
- [ ] Verify the tip renders correctly on the docs site
- [ ] Confirm env var names match the existing table