### PR TITLE
Clarify Manage Custom SQL vs Manage SQL Runner permissions

### DIFF
--- a/references/workspace/custom-roles.mdx
+++ b/references/workspace/custom-roles.mdx
@@ -44,9 +44,6 @@ Custom roles are created at the organization level but are assigned to users or 
    - **View permissions**: Allow users to see content (dashboards, charts, spaces)
    - **Create permissions**: Allow users to create new content
    - **Manage permissions**: Allow users to edit, delete, or administer content
-
-   For a detailed breakdown of commonly confused scopes like **Manage SQL Runner** vs **Manage Custom SQL**, see the [roles and permissions reference](/references/workspace/roles#use-the-sql-runner-vs-create-and-explore-custom-sql-dimensions).
-
 5. Click **Save** to create the role
 
 ![create-new-role.png](/images/references/workspace/create-new-role.png)
@@ -83,6 +80,20 @@ Custom roles are assigned at the project level to provide granular access contro
 2. Find the group you want to assign a role to
 3. Select the custom role from the dropdown
 4. All members of the group will inherit the custom role permissions for this project
+
+## Scope reference
+
+### Manage SQL Runner vs Manage Custom SQL
+
+These two scopes are independent and control different features.
+
+**Manage SQL Runner** controls access to the [SQL Runner](/guides/developer/sql-runner), which lets users write and run ad-hoc SQL queries directly against your data warehouse. It also controls the ability to create [virtual views](/guides/developer/virtual-views) and [write back dbt models](/guides/developer/dbt-write-back) from SQL Runner queries.
+
+**Manage Custom SQL** controls the ability to create [custom SQL dimensions](/guides/custom-fields) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This scope does **not** grant access to the SQL Runner.
+
+<Tip>
+  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these scopes. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries - these scopes only control who can **create** them.
+</Tip>
 
 ## Troubleshooting
 

--- a/references/workspace/custom-roles.mdx
+++ b/references/workspace/custom-roles.mdx
@@ -44,6 +44,9 @@ Custom roles are created at the organization level but are assigned to users or 
    - **View permissions**: Allow users to see content (dashboards, charts, spaces)
    - **Create permissions**: Allow users to create new content
    - **Manage permissions**: Allow users to edit, delete, or administer content
+
+   For a detailed breakdown of commonly confused scopes like **Manage SQL Runner** vs **Manage Custom SQL**, see the [roles and permissions reference](/references/workspace/roles#use-the-sql-runner-vs-create-and-explore-custom-sql-dimensions).
+
 5. Click **Save** to create the role
 
 ![create-new-role.png](/images/references/workspace/create-new-role.png)

--- a/references/workspace/roles.mdx
+++ b/references/workspace/roles.mdx
@@ -29,8 +29,8 @@ Project Admins can invite users to their project and assign users or [groups](/r
 | Create and edit scheduled deliveries                     | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |
 | Create and edit Syncs                                    | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Create and edit charts and dashboards                    | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
-| Use the SQL runner                                       | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
-| Create and explore custom SQL dimensions                 | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
+| [Use the SQL runner](#use-the-sql-runner)                | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
+| [Create and explore custom SQL dimensions](#create-and-explore-custom-sql-dimensions) | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Create virtual views                                     | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Manage project access and permissions                    | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Delete project                                           | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
@@ -38,6 +38,22 @@ Project Admins can invite users to their project and assign users or [groups](/r
 | Use dashboards as code (CLI)                             | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Rename models, dimensions, and metrics (CLI and UI)      | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 
+
+### "Use the SQL Runner" vs "Create and explore custom SQL dimensions"
+
+These two permissions are independent and control different features. If you're using [custom roles](/references/workspace/custom-roles), you'll see these as separate scopes called **Manage SQL Runner** and **Manage Custom SQL**.
+
+#### Use the SQL runner
+
+This permission (the **Manage SQL Runner** scope in custom roles) controls access to the [SQL Runner](/guides/developer/sql-runner), which lets users write and run ad-hoc SQL queries directly against your data warehouse. It also controls the ability to create [virtual views](/guides/developer/virtual-views) and [write back dbt models](/guides/developer/dbt-write-back) from SQL Runner queries.
+
+#### Create and explore custom SQL dimensions
+
+This permission (the **Manage Custom SQL** scope in custom roles) controls the ability to create [custom SQL dimensions](/guides/custom-fields) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This permission does **not** grant access to the SQL Runner.
+
+<Tip>
+  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these permissions. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries — these permissions only control who can **create** them.
+</Tip>
 
 ### Organization Roles
 

--- a/references/workspace/roles.mdx
+++ b/references/workspace/roles.mdx
@@ -52,7 +52,7 @@ This permission (the **Manage SQL Runner** scope in custom roles) controls acces
 This permission (the **Manage Custom SQL** scope in custom roles) controls the ability to create [custom SQL dimensions](/guides/custom-fields) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This permission does **not** grant access to the SQL Runner.
 
 <Tip>
-  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these permissions. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries — these permissions only control who can **create** them.
+  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these permissions. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries - these permissions only control who can **create** them.
 </Tip>
 
 ### Organization Roles

--- a/references/workspace/roles.mdx
+++ b/references/workspace/roles.mdx
@@ -29,8 +29,8 @@ Project Admins can invite users to their project and assign users or [groups](/r
 | Create and edit scheduled deliveries                     | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |
 | Create and edit Syncs                                    | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Create and edit charts and dashboards                    | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
-| [Use the SQL runner](#use-the-sql-runner)                | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
-| [Create and explore custom SQL dimensions](#create-and-explore-custom-sql-dimensions) | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
+| Use the SQL runner                                       | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
+| Create and explore custom SQL dimensions                 | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Create virtual views                                     | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Manage project access and permissions                    | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Delete project                                           | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
@@ -38,22 +38,6 @@ Project Admins can invite users to their project and assign users or [groups](/r
 | Use dashboards as code (CLI)                             | <Icon icon="square-check" iconType="solid" /> | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 | Rename models, dimensions, and metrics (CLI and UI)      | <Icon icon="square-check" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" /> |     <Icon icon="xmark" iconType="solid" />    |     <Icon icon="xmark" iconType="solid" />    |
 
-
-### "Use the SQL Runner" vs "Create and explore custom SQL dimensions"
-
-These two permissions are independent and control different features. If you're using [custom roles](/references/workspace/custom-roles), you'll see these as separate scopes called **Manage SQL Runner** and **Manage Custom SQL**.
-
-#### Use the SQL runner
-
-This permission (the **Manage SQL Runner** scope in custom roles) controls access to the [SQL Runner](/guides/developer/sql-runner), which lets users write and run ad-hoc SQL queries directly against your data warehouse. It also controls the ability to create [virtual views](/guides/developer/virtual-views) and [write back dbt models](/guides/developer/dbt-write-back) from SQL Runner queries.
-
-#### Create and explore custom SQL dimensions
-
-This permission (the **Manage Custom SQL** scope in custom roles) controls the ability to create [custom SQL dimensions](/guides/custom-fields) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This permission does **not** grant access to the SQL Runner.
-
-<Tip>
-  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these permissions. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries - these permissions only control who can **create** them.
-</Tip>
 
 ### Organization Roles
 


### PR DESCRIPTION
## Summary
- Adds a new section to the [roles and permissions reference](/references/workspace/roles) explaining the difference between "Use the SQL Runner" (Manage SQL Runner scope) and "Create and explore custom SQL dimensions" (Manage Custom SQL scope)
- Clarifies that users don't need either permission to *query* tables with existing custom SQL dimensions — only to *create* them
- Cross-links from the custom roles page to the new explanatory section

## Context
Addresses [AE-214](https://linear.app/lightdash/issue/AE-214) — a customer was confused about the difference between "Manage Custom SQL" and "Manage SQL Runner" permission scopes when configuring custom roles (Pylon #8859).

## Test plan
- [x] Verify the anchor links work correctly in the rendered docs
- [x] Confirm the Tip callout renders properly
- [x] Review that the explanations match the actual product behavior