### PR TITLE
Add safety warnings for lightdash deploy vs lightdash preview

### DIFF
--- a/guides/cli/how-to-use-lightdash-deploy.mdx
+++ b/guides/cli/how-to-use-lightdash-deploy.mdx
@@ -16,9 +16,16 @@ This guide will walk you through how it works, when to use each option, and what
 ## Before you deploy: A quick word of caution
 
 <Warning>
-Running `lightdash deploy` uses your local dbt profile (from your `profiles.yml`). If your local profile isn't pointing to production, you could deploy to the wrong environment. 
-This works in simple setups, but can introduce risk when using multiple environments or working in a team.
+**`lightdash deploy` pushes directly to your production project.**
+
+Running this command uses your local dbt profile (from your `profiles.yml`). If your default target points to a dev or staging environment, `lightdash deploy` will overwrite your production semantic layer with that configuration — breaking dashboards for all users.
+
+This is the most common way teams accidentally break production. If you're working locally, **use [`lightdash preview`](/guides/cli/how-to-use-lightdash-preview) instead** — it creates a temporary, isolated project that won't affect production.
 </Warning>
+
+<Tip>
+**Using AI coding assistants?** Tools like Claude, Cursor, and other AI assistants may run CLI commands on your behalf. Make sure any AI tooling in your workflow uses `lightdash preview` (not `lightdash deploy`) for local development. You can enforce this by adding instructions to your project's `CLAUDE.md`, `.cursorrules`, or equivalent configuration file.
+</Tip>
 
 For a safer, scalable approach to deploying and previewing changes, use CI/CD. This allows you to:
 

--- a/guides/cli/how-to-use-lightdash-deploy.mdx
+++ b/guides/cli/how-to-use-lightdash-deploy.mdx
@@ -18,14 +18,10 @@ This guide will walk you through how it works, when to use each option, and what
 <Warning>
 **`lightdash deploy` pushes directly to your production project.**
 
-Running this command uses your local dbt profile (from your `profiles.yml`). If your default target points to a dev or staging environment, `lightdash deploy` will overwrite your production semantic layer with that configuration — breaking dashboards for all users.
+Running this command uses your local dbt profile (from your `profiles.yml`). If your default target points to a dev or staging environment, `lightdash deploy` will overwrite your production semantic layer with that configuration, breaking dashboards for all users.
 
-This is the most common way teams accidentally break production. If you're working locally, **use [`lightdash preview`](/guides/cli/how-to-use-lightdash-preview) instead** — it creates a temporary, isolated project that won't affect production.
+If you're working locally, **use [`lightdash preview`](/guides/cli/how-to-use-lightdash-preview) instead**. It creates a temporary, isolated project that won't affect production.
 </Warning>
-
-<Tip>
-**Using AI coding assistants?** Tools like Claude, Cursor, and other AI assistants may run CLI commands on your behalf. Make sure any AI tooling in your workflow uses `lightdash preview` (not `lightdash deploy`) for local development. You can enforce this by adding instructions to your project's `CLAUDE.md`, `.cursorrules`, or equivalent configuration file.
-</Tip>
 
 For a safer, scalable approach to deploying and previewing changes, use CI/CD. This allows you to:
 
@@ -60,7 +56,7 @@ If your dbt project uses different profiles or targets for dev and prod, you can
 lightdash deploy --profile prod
 ```
 <Warning>
-Be careful — if your local prod profile isn't properly pointing to your production database, 
+Be careful. If your local prod profile isn't properly pointing to your production database,
 this can result in incorrect connections (e.g. accidentally deploying to a dev dataset).
 </Warning>
 

--- a/guides/cli/how-to-use-lightdash-preview.mdx
+++ b/guides/cli/how-to-use-lightdash-preview.mdx
@@ -6,6 +6,10 @@ icon: "vial"
 
 Preview projects will copy all spaces/charts/dashboards into your new preview project, so you can test the content and also run [validation](/guides/cli/how-to-use-lightdash-validate). This is only copied on preview creation, you can't sync the content afterwards.
 
+<Tip>
+**Always use `lightdash preview` when developing locally.** Unlike `lightdash deploy`, which pushes directly to your production project, `lightdash preview` creates a temporary, isolated environment where you can safely test changes without affecting production dashboards. When you're ready to deploy to production, use [CI/CD](/guides/cli/automate-cli-workflow) or see the [deploy guide](/guides/cli/how-to-use-lightdash-deploy).
+</Tip>
+
 ### Run `lightdash preview` from inside your project
 
 ```bash

--- a/guides/cli/how-to-use-lightdash-preview.mdx
+++ b/guides/cli/how-to-use-lightdash-preview.mdx
@@ -6,10 +6,6 @@ icon: "vial"
 
 Preview projects will copy all spaces/charts/dashboards into your new preview project, so you can test the content and also run [validation](/guides/cli/how-to-use-lightdash-validate). This is only copied on preview creation, you can't sync the content afterwards.
 
-<Tip>
-**Always use `lightdash preview` when developing locally.** Unlike `lightdash deploy`, which pushes directly to your production project, `lightdash preview` creates a temporary, isolated environment where you can safely test changes without affecting production dashboards. When you're ready to deploy to production, use [CI/CD](/guides/cli/automate-cli-workflow) or see the [deploy guide](/guides/cli/how-to-use-lightdash-deploy).
-</Tip>
-
 ### Run `lightdash preview` from inside your project
 
 ```bash

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -370,13 +370,13 @@ lightdash stop-preview "neon unicorn"
 Compiles and deploys the current project to your [selected Lightdash Cloud project](#lightdash-config-set-project).
 
 <Warning>
-  **`lightdash deploy` pushes directly to your production project. Use with caution.**
+  **`lightdash deploy` pushes directly to your production project.**
 
   Running this command from a local branch will overwrite your production semantic layer with whatever is compiled locally, including any dev or staging targets from your `profiles.yml`. This can break dashboards for all users.
 
   **Use [`lightdash preview`](#lightdash-preview) for local development and testing.** Preview creates a temporary, isolated project that won't affect production.
 
-  For production deploys, we recommend using [CI/CD with GitHub Actions](/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action) instead of running `lightdash deploy` from the CLI.
+  For production deploys, we recommend using [CI/CD with GitHub Actions](/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action).
 </Warning>
 
 All standard [dbt options](#dbt-options) work with `lightdash deploy`.

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -372,13 +372,11 @@ Compiles and deploys the current project to your [selected Lightdash Cloud proje
 <Warning>
   **`lightdash deploy` pushes directly to your production project. Use with caution.**
 
-  Running this command from a local branch will overwrite your production semantic layer with whatever is compiled locally — including any dev or staging targets from your `profiles.yml`. This can break dashboards for all users.
+  Running this command from a local branch will overwrite your production semantic layer with whatever is compiled locally, including any dev or staging targets from your `profiles.yml`. This can break dashboards for all users.
 
   **Use [`lightdash preview`](#lightdash-preview) for local development and testing.** Preview creates a temporary, isolated project that won't affect production.
 
   For production deploys, we recommend using [CI/CD with GitHub Actions](/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action) instead of running `lightdash deploy` from the CLI.
-
-  This is especially important if you're using AI coding assistants (like Claude, Cursor, etc.) that may run CLI commands — make sure they use `lightdash preview`, not `lightdash deploy`.
 </Warning>
 
 All standard [dbt options](#dbt-options) work with `lightdash deploy`.

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -370,9 +370,15 @@ lightdash stop-preview "neon unicorn"
 Compiles and deploys the current project to your [selected Lightdash Cloud project](#lightdash-config-set-project).
 
 <Warning>
-  **It is not common practice to use this command from the CLI after initial project creation.**
+  **`lightdash deploy` pushes directly to your production project. Use with caution.**
 
-  This command is usually [used in Github Actions](/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action) or other deploy scripts.
+  Running this command from a local branch will overwrite your production semantic layer with whatever is compiled locally — including any dev or staging targets from your `profiles.yml`. This can break dashboards for all users.
+
+  **Use [`lightdash preview`](#lightdash-preview) for local development and testing.** Preview creates a temporary, isolated project that won't affect production.
+
+  For production deploys, we recommend using [CI/CD with GitHub Actions](/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action) instead of running `lightdash deploy` from the CLI.
+
+  This is especially important if you're using AI coding assistants (like Claude, Cursor, etc.) that may run CLI commands — make sure they use `lightdash preview`, not `lightdash deploy`.
 </Warning>
 
 All standard [dbt options](#dbt-options) work with `lightdash deploy`.


### PR DESCRIPTION
## Summary
- Added clear warnings to `lightdash deploy` in the CLI reference and deploy guide explaining it pushes directly to production
- Recommends `lightdash preview` for local development and CI/CD for production deploys

## Context
Addresses [AE-212](https://linear.app/lightdash/issue/AE-212). A customer overwrote their production semantic layer by running `lightdash deploy` from a local branch (Pylon #10751).

## Test plan
- [x] Verify warnings render on CLI reference page and deploy guide