### PR TITLE
docs: add user attribution and OAuth guidance for Slack AI agents

### DIFF
--- a/references/integrations/slack-integration.mdx
+++ b/references/integrations/slack-integration.mdx
@@ -38,6 +38,20 @@ Configure how AI Agents interact with your Slack workspace. You can control whet
 
 For details on Slack channel limitations and multi-agent support, see [Slack channel limitations](/guides/ai-agents/getting-started#slack-channel-limitations).
 
+#### User attribution and OAuth
+
+By default, all AI agent conversations in Slack are attributed to the user who installed the Slack app (or created the agent). This means every Slack user's questions will appear as if they came from that single user, and all queries will run with that user's permissions.
+
+To have each Slack user properly identified and use their own permissions, enable the **AI Agents OAuth requirement** toggle in these settings. When enabled:
+
+- Each Slack user must authenticate with Lightdash before using the AI agent
+- Conversations are attributed to the individual user asking the question
+- Queries respect each user's own [user attributes and permissions](/guides/ai-agents/data-access#user-attributes-and-permissions)
+
+<Tip>
+We recommend enabling OAuth if your organization uses row-level or column-level security through user attributes, or if you need an audit trail of which users are asking which questions.
+</Tip>
+
 ## Using Lightdash in private channels
 
 Lightdash supports private Slack channels, but because Slack doesn't allow apps to see private channels by default, you'll need to manually add the Lightdash app to your private channel first.
@@ -123,4 +137,7 @@ The Slack integration is also used by AI analyst agents to chat with your data a
 
 To trigger AI responses, mention the Lightdash app in your message. There's only one Lightdash Slack app name to mention - you don't need to specify a particular agent. Lightdash automatically routes your question to the most appropriate agent. If it's unclear which agent should respond, you'll be prompted to choose.
 
+<Note>
+By default, all Slack AI agent conversations are attributed to the user who installed the Slack app. To have conversations attributed to individual Slack users (and respect their data permissions), enable the **AI Agents OAuth requirement** in your [Slack integration settings](#ai-agents-configuration).
+</Note>
 


### PR DESCRIPTION
## Summary
- Adds a new "User attribution and OAuth" subsection under the AI Agents configuration settings, explaining that by default all Slack conversations are attributed to the installing user
- Documents how enabling the OAuth requirement toggle fixes this by having each user authenticate individually
- Adds a brief note in the AI analyst agents section linking back to the configuration

Closes [AE-211](https://linear.app/lightdash/issue/AE-211/docs-ai-slack-bot-oauth-for-user-attribution)

## Test plan
- [ ] Verify the new section renders correctly on the docs site
- [ ] Confirm internal links (`#ai-agents-configuration` anchor, `/guides/ai-agents/data-access#user-attributes-and-permissions`) resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)