### PR TITLE
Add docs for total() and row_total() table calculation functions

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,8 @@
                     "group": "Table calculation functions",
                     "pages": [
                       "references/table-calculation-functions/row-functions",
-                      "references/table-calculation-functions/pivot-functions"
+                      "references/table-calculation-functions/pivot-functions",
+                      "references/table-calculation-functions/aggregate-functions"
                     ]
                   },
                   {

--- a/guides/table-calculations.mdx
+++ b/guides/table-calculations.mdx
@@ -68,6 +68,7 @@ In addition to writing raw SQL, you can use built-in functions that simplify com
 
 - **[Row functions](/references/table-calculation-functions/row-functions)** — Access values from other rows (e.g., previous row, specific row number, lookups)
 - **[Pivot functions](/references/table-calculation-functions/pivot-functions)** — Access values across pivot columns
+- **[Aggregate functions](/references/table-calculation-functions/aggregate-functions)** — Reference column totals and row totals
 
 These functions compile to SQL window functions automatically, so you don't need to write `LAG`, `LEAD`, or `ROW_NUMBER` by hand.
 
@@ -116,6 +117,6 @@ For example: You use table calculations to calculate the `percentage_of_shipping
 
 ## Table calculation functions and SQL templates
 
-If you prefer not to write raw SQL, check out the built-in [row functions](/references/table-calculation-functions/row-functions) and [pivot functions](/references/table-calculation-functions/pivot-functions) — they handle common patterns like accessing previous rows, row numbering, and working across pivot columns.
+If you prefer not to write raw SQL, check out the built-in [row functions](/references/table-calculation-functions/row-functions), [pivot functions](/references/table-calculation-functions/pivot-functions), and [aggregate functions](/references/table-calculation-functions/aggregate-functions) — they handle common patterns like accessing previous rows, row numbering, working across pivot columns, and computing totals.
 
 For more advanced or custom SQL, we also have copy-paste SQL templates to help you get started with common table calculations. You can check out our table calculation SQL templates [here](/guides/table-calculations/sql-templates).

--- a/references/table-calculation-functions/aggregate-functions.mdx
+++ b/references/table-calculation-functions/aggregate-functions.mdx
@@ -1,0 +1,74 @@
+---
+title: "Aggregate functions"
+description: "Built-in functions for referencing column and row totals in your table calculations."
+---
+
+<Info>
+  **Table calculation functions are an Experimental feature.**
+
+  These functions may change or be updated without notice as we iterate. See [feature maturity levels](/references/workspace/feature-maturity-levels) for details.
+</Info>
+
+Aggregate functions let you reference grand totals and row totals in your table calculations. Unlike [row functions](/references/table-calculation-functions/row-functions) and [pivot functions](/references/table-calculation-functions/pivot-functions) which compile to SQL window functions, aggregate functions generate separate CTEs that compute totals from the underlying data.
+
+This means `total()` correctly handles all metric types — including `count_distinct` and `average` — by re-running the metric's native aggregation rather than naively summing grouped values.
+
+## total
+
+Returns the grand total of a metric across all rows, computed from the raw data using the metric's native aggregation.
+
+```
+total(${table.metric})
+```
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `metric` | metric reference | The metric to compute the grand total for |
+
+**Example**
+
+Calculate each row's share of total revenue:
+
+```
+${orders.total_revenue} / total(${orders.total_revenue})
+```
+
+With percent formatting applied, this gives you each row as a percentage of the overall total.
+
+<Accordion title="How it works">
+Lightdash generates a `column_totals` CTE that re-aggregates the metric from the raw data with no `GROUP BY`, producing a single grand-total value. This value is then cross-joined into the main query.
+
+For a `sum` metric, the CTE computes `SUM(...)`. For `count_distinct`, it computes `COUNT(DISTINCT ...)`. For `average`, it computes `AVG(...)`. Each metric type uses its own native aggregation, so the total is always mathematically correct.
+</Accordion>
+
+---
+
+## row_total
+
+Returns the sum of a metric's values across all pivot columns for the current row.
+
+```
+row_total(${table.metric})
+```
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `metric` | metric reference | The metric to sum across pivot columns |
+
+<Note>
+`row_total` is only available when your query includes a pivoted dimension. If no pivot is configured, `row_total(${table.metric})` falls back to the metric's value directly.
+</Note>
+
+**Example**
+
+In a pivot table with revenue broken out by region, calculate each region's share of the row total:
+
+```
+${orders.total_revenue} / row_total(${orders.total_revenue})
+```
+
+<Accordion title="How it works">
+Lightdash generates a `row_totals` CTE that reads from the already-grouped results and computes `SUM(metric)` grouped by the non-pivot dimensions. This gives one total per row, which is then joined back into the main query.
+
+Unlike `total()`, `row_total()` always uses `SUM` regardless of the metric type, since it's summing pre-aggregated values across the pivot columns within each row.
+</Accordion>


### PR DESCRIPTION
## Summary
- Adds new **Aggregate functions** docs page covering `total()` and `row_total()` table calculation functions
- Adds the page to the sidebar navigation under "Table calculation functions"
- Updates the parent table calculations guide to reference the new aggregate functions page

## Test plan
- [ ] Verify the new page renders correctly at `/references/table-calculation-functions/aggregate-functions`
- [ ] Verify sidebar navigation shows the new page under "Table calculation functions"
- [ ] Verify links from `guides/table-calculations.mdx` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)