### PR TITLE
docs: clarify metric comparison is limited to same table

### DIFF
--- a/guides/metrics-catalog/catalog.mdx
+++ b/guides/metrics-catalog/catalog.mdx
@@ -43,7 +43,9 @@ Visualize your metrics in the **Metrics Explorer**.
 
    * **'This time last year'**: Compare the selected time period to the same period last year
 
-   * **'Another metric':** Compare to any other metric in the project **that has a default time dimension specified in the `.yml`**. This includes joins [See how](#configuring-default-time-settings-in-yml)
+   * **'Another metric':** Compare to another metric **from the same table** that has a default time dimension specified in the `.yml`. [See how](#configuring-default-time-settings-in-yml)
+
+   <Note>Cross-table metric comparison (including joined tables) is not yet supported but is planned. See [GitHub issue #21003](https://github.com/lightdash/lightdash/issues/21003) for updates.</Note>
 
 7. **Drag to zoom:** Click and drag across the chart to highlight the desired time range or data points, then release to zoom in on that segment. Hit 'Reset Zoom' to reset chart.
 
@@ -874,11 +876,13 @@ Not yet, but soon you'll be able to manage metadata directly in the UI and sync 
 
 **d. Which other metrics can I compare my selected metric by?**
 
-1. **Metrics with defaults in `.yml`:** Metrics with a default time dimension specified in the `.yml` file will always appear.
+Currently, the "Compare to another metric" dropdown shows metrics **from the same table** as your selected metric that meet the following criteria:
+
+1. **Metrics with defaults in `.yml`:** Metrics with a default time dimension specified in the `.yml` file will appear.
 
 2. **Metrics with a single time dimension:** Metrics from tables with only one time dimension will appear as it's assumed to be the most relevant.
 
-3. **Metrics from joined tables:** Metrics from joined tables that meet the criteria in points 1 and 2 will also appear.
+<Note>Cross-table metric comparison (including joined tables) is not yet supported. See [GitHub issue #21003](https://github.com/lightdash/lightdash/issues/21003) for updates.</Note>
 
 **e. How can I be sure that my yml changes are correct?**
 


### PR DESCRIPTION
## Summary
- Updated the "Compare to another metric" description to state it only shows metrics from the **same table** (not cross-table/joined metrics as previously documented)
- Updated FAQ item (d) to reflect the same-table limitation
- Added notes linking to [lightdash/lightdash#21003](https://github.com/lightdash/lightdash/issues/21003) which tracks cross-table comparison support

## Context
A customer reported (Pylon #11279) that the "Compare to another metric" dropdown only shows same-table metrics, contradicting the docs. Internal investigation confirmed this was an intentional first-iteration limitation introduced in [lightdash/lightdash#19727](https://github.com/lightdash/lightdash/pull/19727), but the docs were never updated.