### PR TITLE
docs: clarify JWT filter config must be inside content object

### DIFF
--- a/guides/embedding/dashboards.mdx
+++ b/guides/embedding/dashboards.mdx
@@ -56,6 +56,10 @@ While the SDK options are configured via React props, iframe options are configu
 
 Dashboard filters allow users to slice and filter data across all charts in the dashboard. You can control whether users can interact with these filters, which filters they can modify, and whether the filter UI is visible.
 
+<Warning>
+All interactivity options like `dashboardFiltersInteractivity`, `canExportCsv`, `canExplore`, etc. must be placed **inside the `content` object** in your JWT payload — not at the top level. See the [complete configuration example](#complete-configuration-example) for the full structure.
+</Warning>
+
 **Configure in JWT:**
 
 ```javascript
@@ -94,9 +98,13 @@ Dashboard filters allow users to slice and filter data across all charts in the 
 
 ```javascript
 {
-  dashboardFiltersInteractivity: {
-    enabled: 'all',
-    hidden: true,  // Filters work but UI is hidden
+  content: {
+    type: 'dashboard',
+    dashboardUuid: 'your-dashboard-uuid',
+    dashboardFiltersInteractivity: {
+      enabled: 'all',
+      hidden: true,  // Filters work but UI is hidden
+    },
   }
 }
 ```

--- a/references/embedding.mdx
+++ b/references/embedding.mdx
@@ -76,7 +76,11 @@ All tokens share these fields:
 
 ### Dashboard token
 
-For embedding dashboards with multiple tiles, filters, and interactive features:
+For embedding dashboards with multiple tiles, filters, and interactive features.
+
+<Warning>
+All configuration options (`dashboardFiltersInteractivity`, `canExportCsv`, `canExplore`, etc.) must be nested **inside the `content` object** — not at the top level of the JWT payload. A common mistake is placing these properties at the root level, which will cause them to be silently ignored.
+</Warning>
 
 ```typescript
 {


### PR DESCRIPTION
## Summary
- Fixed misleading code snippet in the dashboards embedding guide where `dashboardFiltersInteractivity` was shown without the `content` wrapper — this is exactly what caused the customer confusion in the support ticket
- Added warning callouts in both the guide and reference docs reminding developers that all interactivity options must be nested inside `content`

Closes https://linear.app/lightdash/issue/AE-213

## Test plan
- [ ] Preview the Mintlify docs and verify the warning callouts render correctly
- [ ] Verify the "Hide filter UI" code snippet now includes the full `content` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)