### PR TITLE
Move Loom video to dedicated Map chart page

### DIFF
--- a/references/chart-types/custom-charts.mdx
+++ b/references/chart-types/custom-charts.mdx
@@ -944,8 +944,6 @@ The config below will output a waterfall chart with the standard Vega-Lite setti
 
 ### Map charts
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/23e6301e4d494168a5946273b86c0423" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
-
 Map charts are perfect for visualizing data that has geographic coordinates, such as customer locations, sales regions, or shipment routes. They combine a background map (usually countries, states, or regions) with your data points overlaid as markers.
 
 This chart works best when you have **latitude and longitude fields** or a TopoJSON lookup with some ID or unique lookup name to plot the points on the map, and a numeric metric to adjust the size of each point or color gradient (like total sales or number of customers).

--- a/references/chart-types/map.mdx
+++ b/references/chart-types/map.mdx
@@ -10,6 +10,8 @@ icon: "earth-europe"
   </Card>
 </a>
 
+<iframe width="100%" height="420" src="https://www.loom.com/embed/23e6301e4d494168a5946273b86c0423" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
+
 ![map](/images/references/chart-types/map/intro.png)
 
 Maps display geographic data on an interactive map. They support three visualization modes:


### PR DESCRIPTION
## Summary
- Removes the Loom video embed from the custom charts reference page (`custom-charts.mdx`)
- Adds it to the dedicated Map (Beta) page (`map.mdx`) where it belongs

## Context
PR #514 placed the video in the custom charts section instead of the dedicated map page. This moves it to the correct location.

## Test plan
- [ ] Verify the video renders correctly on the Map (Beta) page
- [ ] Verify the custom charts page no longer shows the video under the Map charts section

🤖 Generated with [Claude Code](https://claude.com/claude-code)