### PR TITLE
docs: add HAR file generation guide

### DIFF
--- a/contact/generating-har-file.mdx
+++ b/contact/generating-har-file.mdx
@@ -1,0 +1,96 @@
+---
+title: "Generating a HAR file"
+description: "How to capture a HAR file from your browser to help the Lightdash support team troubleshoot issues"
+---
+
+When troubleshooting issues with Lightdash, our support team may ask you to provide a **HAR (HTTP Archive) file**. A HAR file records all network requests between your browser and Lightdash, helping us diagnose loading failures, slow queries, API errors, and other issues.
+
+## Before you start
+
+<Warning>
+  HAR files contain sensitive data including **cookies, session tokens, and the content of pages you visited** during the recording. Anyone with access to a HAR file could use this information to impersonate your session.
+
+  **Before sharing a HAR file:**
+  - Only record the minimum steps needed to reproduce the issue
+  - Do not share HAR files publicly (e.g. in GitHub issues) — send them directly to the support team
+  - If possible, use [Cloudflare's HAR sanitizer](https://har-sanitizer.pages.dev/) to strip cookies and authorization headers before sharing
+</Warning>
+
+## Generating a HAR file
+
+Select your browser below for step-by-step instructions.
+
+<Tabs>
+  <Tab title="Chrome">
+    1. Open the page in Lightdash where you're experiencing the issue
+    2. Open Chrome DevTools: press `F12`, or `Cmd + Option + I` (Mac) / `Ctrl + Shift + I` (Windows/Linux)
+    3. Click the **Network** tab
+    4. Make sure the record button (top-left circle) is **red** — this means recording is active
+    5. Check the **Preserve log** checkbox to keep requests across page navigations
+    6. Click the **clear** button (circle with a line through it) to remove any existing logs
+    7. Reproduce the issue you're troubleshooting
+    8. Right-click anywhere in the network request list and select **Save all as HAR with Content**
+    9. Save the file to your computer
+
+    <Tip>
+      To also capture console errors: click the **Console** tab in DevTools, right-click in the console output, and select **Save as...** to download the console log.
+    </Tip>
+  </Tab>
+
+  <Tab title="Firefox">
+    1. Open the page in Lightdash where you're experiencing the issue
+    2. Open Developer Tools: press `F12`, or `Cmd + Option + I` (Mac) / `Ctrl + Shift + I` (Windows/Linux)
+    3. Click the **Network** tab
+    4. Reproduce the issue you're troubleshooting
+    5. Right-click any request in the network list and select **Save All As HAR**
+    6. Save the file to your computer
+
+    <Tip>
+      To also capture console errors: click the **Console** tab in Developer Tools and take a screenshot of any errors shown.
+    </Tip>
+  </Tab>
+
+  <Tab title="Safari">
+    1. Enable the developer tools if you haven't already: go to **Safari > Settings > Advanced** and check **Show features for web developers**
+    2. Open the page in Lightdash where you're experiencing the issue
+    3. Open Web Inspector: press `Cmd + Option + I`, or go to **Develop > Show Web Inspector**
+    4. Click the **Network** tab
+    5. Make sure **Preserve Log** is checked (click the filter icon in the toolbar if needed)
+    6. Reproduce the issue you're troubleshooting
+    7. Click **Export** in the top-right of the Network tab to save the HAR file
+
+    <Tip>
+      To also capture console errors: click the **Console** tab in Web Inspector and take a screenshot of any errors shown.
+    </Tip>
+  </Tab>
+
+  <Tab title="Microsoft Edge">
+    1. Open the page in Lightdash where you're experiencing the issue
+    2. Open Developer Tools: press `F12`, or `Ctrl + Shift + I`
+    3. Click the **Network** tab
+    4. Make sure the record button is active (red circle)
+    5. Check the **Preserve log** checkbox
+    6. Click the **clear** button to remove any existing logs
+    7. Reproduce the issue you're troubleshooting
+    8. Click the **Export HAR** button (down arrow icon) in the Network tab toolbar
+    9. Save the file to your computer
+
+    <Tip>
+      To also capture console errors: click the **Console** tab in Developer Tools, right-click in the console output, and select **Save as...** to download the console log.
+    </Tip>
+  </Tab>
+</Tabs>
+
+## Sending the HAR file to Lightdash support
+
+1. **Sanitize** the file using [Cloudflare's HAR sanitizer](https://har-sanitizer.pages.dev/) to remove sensitive headers and cookies
+2. **Compress** the file — HAR files can be large, so zip the file before sending (right-click the file and select **Compress** on Mac or **Send to > Compressed folder** on Windows)
+3. **Send** the file to [support@lightdash.com](mailto:support@lightdash.com) with a description of the issue, including:
+   - What you were trying to do
+   - What you expected to happen
+   - What actually happened
+   - The URL of the Lightdash page where the issue occurred
+
+<Note>
+  If the compressed HAR file is too large for email (over 25 MB), let the support team know and they'll provide an alternative upload method.
+</Note>

--- a/docs.json
+++ b/docs.json
@@ -324,7 +324,8 @@
             "group": "Contact",
             "pages": [
               "contact/faqs",
-              "contact/contact-info"
+              "contact/contact-info",
+              "contact/generating-har-file"
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- Adds a new support page (`contact/generating-har-file.mdx`) with step-by-step instructions for generating HAR files across Chrome, Firefox, Safari, and Edge
- Includes security warnings about sensitive data in HAR files and links to Cloudflare's HAR sanitizer
- Adds the page to the Contact navigation group in `docs.json`

## Test plan
- [ ] Verify the page renders correctly at `/contact/generating-har-file`
- [ ] Confirm browser tabs (Chrome, Firefox, Safari, Edge) display and switch correctly
- [ ] Check that the Warning, Tip, and Note callouts render properly
- [ ] Verify the page appears in the Contact section of the sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)