### PR TITLE
docs: rename DuckDB section to MotherDuck

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -45,7 +45,7 @@ We currently support:
 
   <Card title="ClickHouse" icon="container-storage" href="#clickhouse" />
 
-  <Card title="DuckDB" icon="database" href="#duckdb" />
+  <Card title="MotherDuck" icon="database" href="#motherduck" />
 
   <Card title="Athena" icon="aws" href="#athena" />
 
@@ -704,7 +704,8 @@ This controls what day is the start of the week in Lightdash. `Auto` sets it to 
 
 ***
 
-### DuckDB
+<a id="duckdb"></a>
+### MotherDuck
 
 Lightdash supports DuckDB project connections through [MotherDuck](https://motherduck.com/).
 
@@ -736,7 +737,7 @@ This controls what day is the start of the week in Lightdash. `Auto` sets it to 
 
 ##### dbt version
 
-DuckDB connections in Lightdash require dbt `v1.8` or later.
+MotherDuck connections in Lightdash require dbt `v1.8` or later.
 
 If you work with dbt locally, your `profiles.yml` should look similar to this:
 


### PR DESCRIPTION
## Summary
- Renames the "DuckDB" warehouse card and section heading to "MotherDuck" since the section describes MotherDuck connections
- Updates "DuckDB connections" to "MotherDuck connections" in the dbt version note
- Adds a hidden `<a id="duckdb"></a>` anchor to preserve the existing `#duckdb` link so shared URLs don't break

## Test plan
- [ ] Verify `https://docs.lightdash.com/get-started/setup-lightdash/connect-project#motherduck` navigates to the renamed section
- [ ] Verify `https://docs.lightdash.com/get-started/setup-lightdash/connect-project#duckdb` still scrolls to the same section via the hidden anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)