### PR TITLE
Update filter syntax to use arrays instead of comma-separated strings

### DIFF
--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -2014,7 +2014,9 @@ filters:
 
 ### Filtering using a list of values
 
-To filter a field using a list of values you can supply them as an array for that field. For example, if you wanted to filter for orders with order status `completed` or `shipped` you should write the metric like:
+To filter a field using a list of values you can supply them as an array for that field. This generates a SQL `IN` clause, e.g. `WHERE order_status IN ('completed', 'shipped')`.
+
+For example, if you wanted to filter for orders with order status `completed` or `shipped` you should write the metric like:
 
 <Tabs>
   <Tab title="dbt v1.9 and earlier">

--- a/references/tables.mdx
+++ b/references/tables.mdx
@@ -597,7 +597,7 @@ The order that the fields are listed in `default_show_underlying_values` is the 
 Use `default_filters` to define filters on Dimensions that will be applied when no other user-defined filter on those Dimensions exists. Default filters will apply to tables on load and can be populated with a pre-determined value. Use them to suggest to users the kind of filters they might want to consider, or provide a default filtered view of a table that can be changed if needed.
 
 An optional `required` flag can be added, and if this flag is set to `required: true`, the filter for this field cannot be removed from the UI but users can still modify the operator and value to adjust how this filter is applied to the data. This ensures the filter is always applied in some form, while giving users flexibility to change the date range or other values. This can be particularly useful if you have a large table and want to force users to filter on a partitioned date.
-  
+
 In contrast, when `required: false` (or omitted), the filter is pre-populated but fully editable — users can change the field, operator, value, or remove it entirely.
 
 Below you can see there is a default filter with the optional required flag, that will have show the last 14 days of data by default.
@@ -802,7 +802,7 @@ Note that we do also support a _legacy_ structure for defining required filters,
 | is not empty    | Value is not empty string                      | `notes: "!empty"`                  | String          |
 | is [boolean]    | Boolean value is true                          | `is_complete: "true"`               | Boolean         |
 | is not [boolean] | Boolean value is false or null                 | `is_complete: "!true"`            | Boolean         |
-| in list          | Value is in comma-separated list               | `status: "active,pending,approved"` | String, Number  |
+| in list          | Value is in a list of values                   | `status: ["active", "pending", "approved"]` | String, Number  |
 
 
 ### Filter examples
@@ -824,12 +824,20 @@ default_filters:
   - created_at: 'between 2024-01-01T00:00:00 and 2024-12-31T23:59:59'
 ```
 
-**Multiple values (comma-separated list):**
+**Multiple values (list):**
+
+Use an array to filter by multiple values. This generates a SQL `IN` clause, e.g. `WHERE status IN ('active', 'pending', 'approved')`.
 
 ```yaml
 default_filters:
-  - status: 'active,pending,approved'
-  - country: 'US,CA,UK'
+  - status:
+      - 'active'
+      - 'pending'
+      - 'approved'
+  - country:
+      - 'US'
+      - 'CA'
+      - 'UK'
 ```
 
 **Pattern matching:**
@@ -862,7 +870,9 @@ Available intervals: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, `wee
       - name: orders
         meta:
           default_filters:
-            - status: 'completed,shipped'
+            - status:
+                - 'completed'
+                - 'shipped'
             - order_date: 'between 2024-01-01 and 2024-12-31'
             - revenue: '>= 100'
             - country: '!test'
@@ -876,7 +886,9 @@ Available intervals: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, `wee
         config:
           meta:
             default_filters:
-              - status: 'completed,shipped'
+              - status:
+                  - 'completed'
+                  - 'shipped'
               - order_date: 'between 2024-01-01 and 2024-12-31'
               - revenue: '>= 100'
               - country: '!test'
@@ -889,7 +901,9 @@ Available intervals: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, `wee
     name: orders
 
     default_filters:
-      - status: 'completed,shipped'
+      - status:
+          - 'completed'
+          - 'shipped'
       - order_date: 'between 2024-01-01 and 2024-12-31'
       - revenue: '>= 100'
       - country: '!test'


### PR DESCRIPTION
This pull request updates the documentation for filtering with multiple values in both metrics and tables. The changes replace the comma-separated string syntax with an array-based approach for specifying multiple filter values. 

Key changes include:
- Updated the metrics documentation to clarify that filtering with a list of values generates a SQL `IN` clause
- Modified all examples in the tables documentation to use YAML arrays instead of comma-separated strings for multiple values (e.g., `["active", "pending", "approved"]` instead of `"active,pending,approved"`)
- Added explanatory text about SQL `IN` clause generation for better understanding
- Updated the filter operators table to reflect the new array syntax

The new syntax provides better YAML structure and makes the relationship to SQL `IN` clauses more explicit.