### PR TITLE
Add Nix flake for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ out/
 images/.DS_Store
 .DS_Store
 .env/
+
+.direnv/
+.envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Nix flake for Lightdash Docs development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # This covers typical Linux and macOS architectures.x
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config = {
+              allowUnfreePredicate =
+                pkg:
+                builtins.elem (nixpkgs.lib.getName pkg) [
+                  "graphite-cli"
+                ];
+            };
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            name = "lightdash-docs-dev-shell";
+
+            buildInputs = with pkgs; [
+              nodejs
+              graphite-cli
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
This pull request adds Nix flake support for the development environment. The flake provides Node.js and Graphite CLI as development dependencies, with support for Linux and macOS architectures. A `.envrc` file enables automatic environment loading via direnv, and `.direnv/` is added to `.gitignore` to exclude direnv cache files from version control.