### PR TITLE
docs: clarify default/required filters only target visible dimensions

### DIFF
--- a/references/tables.mdx
+++ b/references/tables.mdx
@@ -600,6 +600,8 @@ An optional `required` flag can be added, and if this flag is set to `required: 
 
 In contrast, when `required: false` (or omitted), the filter is pre-populated but fully editable — users can change the field, operator, value, or remove it entirely.
 
+`default_filters` and `required_filters` can only target **dimensions** (including visible `additional_dimensions`). Hidden dimensions (`hidden: true`) are not valid targets and will fail compilation.
+
 Below you can see there is a default filter with the optional required flag, that will have show the last 14 days of data by default.
 
 <Tabs>
@@ -919,6 +921,8 @@ Available intervals: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, `wee
 - **Escaping**: Use `^` to escape special characters (`%`, `_`, `,`, `!`, `^`)
 - **AND logic**: Multiple filters are automatically joined with AND
 - **Priority**: Default filters only apply when no user-specified filter exists for that dimension
+- **Supported fields**: `default_filters` and `required_filters` apply to dimensions only (not metrics)
+- **Hidden fields**: Hidden dimensions (`hidden: true`) cannot be used in `default_filters`/`required_filters`
 
 ## Case sensitive
 


### PR DESCRIPTION
This pull request adds documentation clarifying that `default_filters` and `required_filters` can only target dimensions, not metrics or hidden dimensions. The changes specify that these filters must target visible dimensions (including `additional_dimensions`) and that hidden dimensions with `hidden: true` are invalid targets that will cause compilation to fail.