### PR TITLE
Add self-hosted MCP setup instructions

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -307,6 +307,7 @@
                 "group": "Customize deployment",
                 "pages": [
                   "self-host/customize-deployment/enterprise-license-keys",
+                  "self-host/customize-deployment/configure-mcp-for-lightdash",
                   "self-host/customize-deployment/configure-a-slack-app-for-lightdash",
                   "self-host/customize-deployment/configure-github-for-lightdash",
                   "self-host/customize-deployment/configure-lightdash-to-use-an-external-database",

--- a/self-host/customize-deployment/configure-mcp-for-lightdash.mdx
+++ b/self-host/customize-deployment/configure-mcp-for-lightdash.mdx
@@ -1,0 +1,60 @@
+---
+title: Configure MCP for self-hosted Lightdash
+description: "Enable the Model Context Protocol (MCP) integration on your self-hosted Lightdash instance."
+sidebarTitle: MCP integration
+---
+
+<Note>
+🛠 This page is for engineering teams self-hosting their own Lightdash instance. If you want to use MCP with Lightdash Cloud, go to the [Lightdash MCP](/references/integrations/lightdash-mcp) guide.
+</Note>
+
+<Warning>
+🔑 **Enterprise feature** — MCP on self-hosted instances requires a valid [Enterprise License Key](/self-host/customize-deployment/enterprise-license-keys). Without an active license, the MCP service will not be registered and the `/api/v1/mcp` endpoint will return an error.
+</Warning>
+
+## Prerequisites
+
+- A self-hosted Lightdash instance
+- A valid `LIGHTDASH_LICENSE_KEY` configured ([setup guide](/self-host/customize-deployment/enterprise-license-keys))
+
+## Enable MCP
+
+Set the following environment variable on your Lightdash deployment:
+
+```bash
+MCP_ENABLED=true
+```
+
+No additional services or external OAuth configuration is needed — the OAuth server is built into Lightdash, so the authentication flow works the same as Lightdash Cloud once MCP is enabled.
+
+## MCP URL format
+
+Once enabled, the MCP endpoint is available at:
+
+```
+https://<your-lightdash-host>/api/v1/mcp
+```
+
+Replace `<your-lightdash-host>` with your instance's domain (e.g. `lightdash.yourcompany.com`).
+
+## Connect an AI assistant
+
+Follow the same setup steps as Lightdash Cloud, using your self-hosted URL instead of a `.lightdash.cloud` address. See the [Lightdash MCP installation guide](/references/integrations/lightdash-mcp#installation) for detailed instructions for each AI assistant (Claude, ChatGPT, Codex, Cursor, Claude Code).
+
+For example, with Claude Code:
+
+```bash
+claude mcp add lightdash https://<your-lightdash-host>/api/v1/mcp -t http
+```
+
+## Network requirements
+
+If your Lightdash instance is behind a firewall or VPN, ensure the MCP client can reach your Lightdash host over HTTPS. See the [network requirements](/references/integrations/lightdash-mcp#network-requirements) section for additional domains that may need to be allowlisted depending on your AI assistant.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `/api/v1/mcp` returns an error or 404 | `MCP_ENABLED` is not set to `true`, or the license key is missing/invalid |
+| OAuth flow fails | Ensure your Lightdash instance is reachable from the browser performing the OAuth redirect |
+| AI assistant can't connect | Check that the MCP URL is correct and the instance is accessible over HTTPS |

--- a/self-host/enterprise-on-prem.mdx
+++ b/self-host/enterprise-on-prem.mdx
@@ -53,6 +53,7 @@ Once your license key is active, most Enterprise features are controlled by envi
 | AI agents | `AI_AGENTS_ENABLED=true` | [AI agents](/guides/ai-agents) |
 | Caching | `RESULTS_CACHE_ENABLED=true` | [Caching](/guides/developer/caching) |
 | Embedding | `EMBEDDING_ENABLED=true` | [Embedding](/references/embedding) |
+| MCP | `MCP_ENABLED=true` | [MCP integration](/self-host/customize-deployment/configure-mcp-for-lightdash) |
 
 You can [search "enterprise" on the environment variables page](/self-host/customize-deployment/environment-variables) to see all variables that require an Enterprise license key.
 


### PR DESCRIPTION
## Summary
- Adds new self-host page `configure-mcp-for-lightdash.mdx` with enterprise license warning, `MCP_ENABLED=true` env var, self-hosted URL format, and troubleshooting guide
- Adds MCP to the enterprise features table in `enterprise-on-prem.mdx`
- Registers new page in `docs.json` nav under "Customize deployment"

Closes https://linear.app/lightdash/issue/PROD-6926

## Test plan
- [ ] Verify the new page renders correctly in Mintlify preview
- [ ] Confirm nav link appears under Self-hosting > Customize deployment
- [ ] Check enterprise-on-prem table row links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)