### PR TITLE
docs: document SLACK_MULTI_AGENT_CHANNEL_ENABLED for self-hosted

### DIFF
--- a/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
+++ b/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
@@ -146,3 +146,11 @@ Add the following environment variables to your Lightdash server configuration:
 #### Step 3: Re-install the Slack Integration
 
 After updating your environment variables, restart your Lightdash service, then re-install the Slack integration in your Lightdash instance to complete the Socket Mode setup. Your Slack integration will now use Socket Mode to communicate with Slack instead of HTTP webhooks.
+
+## Enable multi-agent Slack channels
+
+By default, each AI agent can only be connected to one Slack channel. To allow multiple agents to share the same Slack channel, enable the [multi-agent Slack channel](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature by setting the following environment variable on your Lightdash instance:
+
+* `SLACK_MULTI_AGENT_CHANNEL_ENABLED`: Set to `"true"` to enable multi-agent Slack channels for the whole instance (default=false)
+
+Restart your Lightdash service after updating the variable. Once enabled, configure the designated channel from **Organization Settings → Integrations → Slack**.

--- a/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
+++ b/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
@@ -146,11 +146,3 @@ Add the following environment variables to your Lightdash server configuration:
 #### Step 3: Re-install the Slack Integration
 
 After updating your environment variables, restart your Lightdash service, then re-install the Slack integration in your Lightdash instance to complete the Socket Mode setup. Your Slack integration will now use Socket Mode to communicate with Slack instead of HTTP webhooks.
-
-## Enable multi-agent Slack channels (Beta)
-
-By default, each AI agent can only be connected to one Slack channel. To allow multiple agents to share the same Slack channel, enable the [multi-agent Slack channel (Beta)](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature by setting the following environment variable on your Lightdash instance:
-
-* `SLACK_MULTI_AGENT_CHANNEL_ENABLED`: Set to `"true"` to enable multi-agent Slack channels for the whole instance (default=false)
-
-Restart your Lightdash service after updating the variable. Once enabled, configure the designated channel from **Organization Settings → Integrations → Slack**.

--- a/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
+++ b/self-host/customize-deployment/configure-a-slack-app-for-lightdash.mdx
@@ -147,9 +147,9 @@ Add the following environment variables to your Lightdash server configuration:
 
 After updating your environment variables, restart your Lightdash service, then re-install the Slack integration in your Lightdash instance to complete the Socket Mode setup. Your Slack integration will now use Socket Mode to communicate with Slack instead of HTTP webhooks.
 
-## Enable multi-agent Slack channels
+## Enable multi-agent Slack channels (Beta)
 
-By default, each AI agent can only be connected to one Slack channel. To allow multiple agents to share the same Slack channel, enable the [multi-agent Slack channel](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature by setting the following environment variable on your Lightdash instance:
+By default, each AI agent can only be connected to one Slack channel. To allow multiple agents to share the same Slack channel, enable the [multi-agent Slack channel (Beta)](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature by setting the following environment variable on your Lightdash instance:
 
 * `SLACK_MULTI_AGENT_CHANNEL_ENABLED`: Set to `"true"` to enable multi-agent Slack channels for the whole instance (default=false)
 

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -341,7 +341,7 @@ These variables enable you to configure the [Slack integration](/guides/using-sl
 | `SLACK_SOCKET_MODE`          | Enable socket mode for Slack (default=false)                              |
 | `SLACK_CHANNELS_CACHED_TIME` | Time in milliseconds to cache Slack channels (default=600000, 10 minutes) |
 | `SLACK_SUPPORT_URL`          | URL for Slack support                                                     |
-| `SLACK_MULTI_AGENT_CHANNEL_ENABLED` | Enables the [multi-agent Slack channel](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature for the whole instance (default=false) |
+| `SLACK_MULTI_AGENT_CHANNEL_ENABLED` | Enables the [multi-agent Slack channel (Beta)](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature for the whole instance (default=false) |
 
 ## GitHub Integration
 

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -341,6 +341,7 @@ These variables enable you to configure the [Slack integration](/guides/using-sl
 | `SLACK_SOCKET_MODE`          | Enable socket mode for Slack (default=false)                              |
 | `SLACK_CHANNELS_CACHED_TIME` | Time in milliseconds to cache Slack channels (default=600000, 10 minutes) |
 | `SLACK_SUPPORT_URL`          | URL for Slack support                                                     |
+| `SLACK_MULTI_AGENT_CHANNEL_ENABLED` | Enables the [multi-agent Slack channel](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) feature for the whole instance (default=false) |
 
 ## GitHub Integration
 

--- a/self-host/enterprise-on-prem.mdx
+++ b/self-host/enterprise-on-prem.mdx
@@ -51,6 +51,7 @@ Once your license key is active, most Enterprise features are controlled by envi
 |---------|---------------------|---------------|
 | Custom roles | `CUSTOM_ROLES_ENABLED=true` | [Custom roles](/references/workspace/custom-roles#custom-roles) |
 | AI agents | `AI_AGENTS_ENABLED=true` | [AI agents](/guides/ai-agents) |
+| Multi-agent Slack channels (Beta) | `SLACK_MULTI_AGENT_CHANNEL_ENABLED=true` | [Multi-agent Slack channels](/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel) |
 | Caching | `RESULTS_CACHE_ENABLED=true` | [Caching](/guides/developer/caching) |
 | Embedding | `EMBEDDING_ENABLED=true` | [Embedding](/references/embedding) |
 | MCP | `MCP_ENABLED=true` | [MCP integration](/self-host/customize-deployment/configure-mcp-for-lightdash) |


### PR DESCRIPTION
## Summary

- Document `SLACK_MULTI_AGENT_CHANNEL_ENABLED` in the self-host Slack env var table
- Add an "Enable multi-agent Slack channels" section to `configure-a-slack-app-for-lightdash` with setup instructions

## Why

Self-hosted instances can't use the PostHog-gated multi-agent Slack feature flag, so they had no documented path to enable multi-agent Slack channels. The env var exists in code but wasn't in the docs. Keeps the AI agents user guide free of self-hosting details — all the deployment config lives under `/self-host`.

## Test plan

- [ ] Verify the Slack env var table renders with the new row
- [ ] Verify the new section renders at the bottom of the self-host Slack config page
- [ ] Verify the cross-link to `/guides/ai-agents/getting-started#setting-up-a-multi-agent-slack-channel` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)