### PR TITLE
docs: add default user spaces reference page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -225,6 +225,7 @@
             "group": "Workspace and user management",
             "pages": [
               "references/workspace/spaces",
+              "references/workspace/default-user-spaces",
               "references/workspace/pinning",
               "references/workspace/personal-tokens",
               "references/workspace/service-accounts",

--- a/references/workspace/default-user-spaces.mdx
+++ b/references/workspace/default-user-spaces.mdx
@@ -1,0 +1,46 @@
+---
+title: "Default user spaces"
+description: "Give every eligible user their own personal space in a project, provisioned automatically on their next login."
+---
+
+Default user spaces give each eligible user a personal space inside a project, so they have a dedicated place to create and manage their own charts, dashboards, and nested spaces without needing an admin to set one up for them.
+
+When the feature is enabled, Lightdash provisions a personal space for each eligible user the next time they log in. The space is created under a parent space called `Default User Spaces`, and is named after the user:
+
+```
+Default User Spaces / <First name> <Last name>
+```
+
+The user is set as an admin of their own default space, so they can self-manage it - creating charts and dashboards, nesting child spaces inside it, and managing access for other users.
+
+## Enabling the feature
+
+Default user spaces are configured per project and are **off by default**.
+
+1. Go to **Project Settings** → **Default user spaces**
+2. Toggle on **Default user spaces**
+
+Once enabled, personal spaces are created lazily: each eligible user gets their space the next time they log in, not immediately on save. Users who never log in after the setting is turned on won't have a space provisioned.
+
+Turning the setting back off stops new spaces from being provisioned, but does not delete any personal spaces that have already been created.
+
+## Who gets a default user space
+
+A user is eligible for a default user space if they have either:
+
+- A project or organization role of **Interactive Viewer** or higher (Interactive Viewer, Editor, Developer, or Admin), or
+- A [custom role](/references/workspace/custom-roles) that includes at least the **Manage Saved Chart** and **Manage Explore** permissions.
+
+Viewers and Members are not eligible, since they can't create charts and dashboards in the first place.
+
+See the [roles and permissions reference](/references/workspace/roles) for the full list of project and organization roles.
+
+## What users can do in their space
+
+Because each user is an admin of their own default space, they can:
+
+- Create charts, dashboards, and nested spaces inside it
+- Move existing content they own into it
+- Manage access - invite other users or groups, or switch the space between Inherited Access and Restricted Access
+
+For more on how space permissions work, see [Spaces](/references/workspace/spaces).


### PR DESCRIPTION
Adding a page with info about the "Default User Spaces" as they should be released to everyone.

Holding it off until the actual release.