### PR TITLE
docs: update data apps clarifying questions flow

### DIFF
--- a/guides/data-apps.mdx
+++ b/guides/data-apps.mdx
@@ -30,7 +30,7 @@ Every new app starts from a template. The template you pick tells the agent what
   ![Clean Shot 2026 04 29 At 18 35 18@2x](/images/CleanShot-2026-04-29-at-18.35.18@2x.png)
 </Frame>
 
-After picking a template (other than Custom), the wizard asks a few short clarifying questions - things like the topic, the audience, and the key metrics you want to highlight. Your answers are used to seed the first prompt, which you can edit before sending.
+After picking a template, you write your first prompt. If the prompt is vague, the agent will ask one or more clarifying questions - things like the topic, the audience, or the key metrics you want to highlight - before it starts building. If your prompt is already specific enough, it skips straight to the build.
 
 Templates only affect the first version of the app. Once you start iterating, the agent works from the existing code and your follow-up prompts.\
 \


### PR DESCRIPTION
Reflect new behavior where clarifying questions are dynamically generated from the first prompt and only appear when the prompt is vague.