### PR TITLE
docs: clarify scopes for custom SQL dimensions vs SQL Runner

### DIFF
--- a/guides/custom-fields.mdx
+++ b/guides/custom-fields.mdx
@@ -95,7 +95,7 @@ You manually define the min and max values for each bin. The custom range option
 
 ### Custom SQL
 
-Custom SQL dimensions let you pull in new data directly from your database, which means they can sometimes be used to bypass access restrictions. **Only users with admin or developer permissions can create custom SQL dimensions**. Regular users will not see this option.
+Custom SQL dimensions let you pull in new data directly from your database, which means they can sometimes be used to bypass access restrictions. **Only users with admin or developer permissions can create custom SQL dimensions** — or, on Enterprise plans, any user assigned a [custom role](/references/workspace/custom-roles) that includes the **Manage Custom Fields** scope (*Create and edit custom dimensions*). Other users will not see authoring options for custom SQL dimensions, but can still use existing ones in their queries.
 
 
 <Info>

--- a/references/workspace/custom-roles.mdx
+++ b/references/workspace/custom-roles.mdx
@@ -103,16 +103,18 @@ Custom roles are assigned at the project level to provide granular access contro
 
 ## Scope reference
 
-### Manage SQL Runner vs Manage Custom SQL
+### SQL-related scopes
 
-These two scopes are independent and control different features.
+Three scopes control different SQL-authoring features. They are independent — granting one does not grant the others.
 
-**Manage SQL Runner** controls access to the [SQL Runner](/guides/developer/sql-runner), which lets users write and run ad-hoc SQL queries directly against your data warehouse. It also controls the ability to create [virtual views](/guides/developer/virtual-views) and [write back dbt models](/guides/developer/dbt-write-back) from SQL Runner queries.
+**Manage Sql Runner** controls access to the [SQL Runner](/guides/developer/sql-runner), which lets users write and run ad-hoc SQL queries directly against your data warehouse. It also controls the ability to create [virtual views](/guides/developer/virtual-views) and [write back dbt models](/guides/developer/dbt-write-back) from SQL Runner queries.
 
-**Manage Custom SQL** controls the ability to create [custom SQL dimensions](/guides/custom-fields) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This scope does **not** grant access to the SQL Runner.
+**Manage Custom Sql** (description: *Save SQL charts*) controls the ability to save the output of a SQL Runner query as a saved chart. Users with this scope can save SQL charts; without it, they can still run queries in SQL Runner but cannot persist the output. This scope does **not** grant access to custom SQL dimensions in Explore.
+
+**Manage Custom Fields** (description: *Create and edit custom dimensions*) controls the ability to create and edit [custom SQL dimensions](/guides/custom-fields#custom-sql) inside the Explore view. Custom SQL dimensions let users add calculated fields to an existing table using raw SQL. This scope does **not** grant access to the SQL Runner.
 
 <Tip>
-  If you want a user to query tables that include custom SQL dimensions created by others, they don't need either of these scopes. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries - these scopes only control who can **create** them.
+  If you want a user to query tables that include custom SQL dimensions created by others, they don't need any of these scopes. Any user with access to the Explore view can **use** existing custom SQL dimensions in their queries — these scopes only control who can **author** them.
 </Tip>
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

The custom-roles scope reference had an incorrect description of which scope controls custom SQL dimensions in Explore. This came up while reviewing docs after [lightdash#22555](https://github.com/lightdash/lightdash/pull/22555), which re-lands the FE hides + diff-aware backend save gate for SQL custom dimension authoring. The PR enforces the \`manage:CustomFields\` scope, but the docs page didn't mention that scope at all.

- \`references/workspace/custom-roles.mdx\`: rename the section from \"Manage SQL Runner vs Manage Custom SQL\" to \"SQL-related scopes\". Correct the \"Manage Custom Sql\" description (it controls saving SQL Runner output as a saved chart, not custom SQL dimensions). Add a third entry for \"Manage Custom Fields\" — *Create and edit custom dimensions* — which is the scope that actually gates custom SQL dimension authoring in Explore.
- \`guides/custom-fields.mdx\`: extend the \"only admin or developer\" line to mention that, on Enterprise, the gate can be opened up to any custom role that includes the \"Manage Custom Fields\" scope. Also clarifies that other users can still **use** existing custom SQL dimensions in queries.

## Test plan

- [ ] Render preview locally / Mintlify preview build passes
- [ ] Verify the new section reads correctly on the custom-roles page (three scope entries, no duplication)
- [ ] Verify the cross-link from \`custom-fields.mdx\` resolves to the custom-roles page

🤖 Generated with [Claude Code](https://claude.com/claude-code)