### PR TITLE
docs: list single eu1 egress IP in allow-list

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -61,7 +61,7 @@ We always recommend giving read-only permissions to Lightdash, that way you ensu
 If you login at:
 
 - **app.lightdash.cloud** use **35.245.81.252**
-- **eu1.lightdash.cloud** use **34.79.239.130**, **34.140.90.83**, and **34.38.17.228**
+- **eu1.lightdash.cloud** use **34.38.17.228**
 
 If you login at a different domain, look for the IP in the project settings page (see image below).
 


### PR DESCRIPTION
## Summary
- Update the EU egress IP allow-list to list `34.38.17.228` only, removing `34.79.239.130` and `34.140.90.83`.

## Test plan
- [ ] Preview `get-started/setup-lightdash/connect-project.mdx` and confirm the eu1 bullet renders the single IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)