### PR TITLE
docs: point Leave organization at Settings → Profile

### DIFF
--- a/references/workspace/managing-your-organization.mdx
+++ b/references/workspace/managing-your-organization.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Managing your organization"
-description: "Leave or delete your Lightdash organization from the Danger zone in General settings."
+description: "Leave or delete your Lightdash organization from the Danger zone in your settings."
 ---
 
-The **Danger zone** at the bottom of **Settings → General** is where you can either leave the organization (any member) or delete it entirely (admins only). Both actions are irreversible.
+A **Danger zone** in your settings is where you can either leave the organization (any member) or delete it entirely (admins only). Both actions are irreversible.
+
+The **Leave** button is available to every member from **Settings → Profile**. The **Delete** button is admin-only and lives in **Settings → General** (admins see the Leave button in that same Danger zone too).
 
 ## Leaving an organization
 
@@ -11,7 +13,7 @@ Any member of an organization can leave it from their own settings — they don'
 
 ### How to leave
 
-1. Go to **Settings → General**.
+1. Go to **Settings → Profile**.
 2. In the **Danger zone** card at the bottom, click **Leave '<your organization>'**.
 3. Type the name of the organization into the confirmation field to confirm.
 4. Click **Leave**.


### PR DESCRIPTION
## Summary

Companion to lightdash/lightdash#22983. The product now renders the **Leave** button inside a Danger zone card on **Settings → Profile** so every role can reach it from a sidebar link they already have.

Before that change, the docs sent users to **Settings → General** — whose sidebar entry is gated by \`manage Organization\`, i.e. admin-only. Non-admins reading the docs would have followed the instructions and found no way to navigate to the page they were told to open.

## What changed

- The intro now names two locations: Leave under Profile (everyone), Delete under General (admins).
- The **How to leave** steps point to **Settings → Profile**.
- The **How to delete** steps and the rest of the page are unchanged — Delete is still admin-only and still lives on Settings → General.

## Verification

- Diff is 3-line semantic + 1 description tweak; no structural changes.
- Mintlify build is unaffected (only an .mdx body edit; no new components, no new links, no nav file changes).

Pairs with lightdash/lightdash#22983
Follow-up to lightdash/mintlify-docs#609

🤖 Generated with [Claude Code](https://claude.com/claude-code)