### PR TITLE
fix(workspace): escape angle brackets in '<your organization>' placeholders

### DIFF
--- a/references/workspace/managing-your-organization.mdx
+++ b/references/workspace/managing-your-organization.mdx
@@ -14,7 +14,7 @@ Any member of an organization can leave it from their own settings — they don'
 ### How to leave
 
 1. Go to **Settings → Profile**.
-2. In the **Danger zone** card at the bottom, click **Leave '<your organization>'**.
+2. In the **Danger zone** card at the bottom, click **Leave '&lt;your organization&gt;'**.
 3. Type the name of the organization into the confirmation field to confirm.
 4. Click **Leave**.
 
@@ -31,7 +31,7 @@ Only users with **organization admin** access see the Delete option in the Dange
 ### How to delete
 
 1. Go to **Settings → General**.
-2. In the **Danger zone** card, click **Delete '<your organization>'**.
+2. In the **Danger zone** card, click **Delete '&lt;your organization&gt;'**.
 3. Type the name of the organization into the confirmation field to confirm.
 4. Click **Delete**.
 


### PR DESCRIPTION
## Summary
- Mintlify deployment was failing with `Expected a closing tag for <your> (17:62-17:81) before the end of strong` on `references/workspace/managing-your-organization.mdx`.
- The page uses the literal placeholder `<your organization>` inside bold button labels. MDX interprets `<your` as a JSX opening tag.
- Replaced the angle brackets with `&lt;` / `&gt;` so the rendered output is unchanged while MDX no longer tries to parse a JSX element.

## Test plan
- [ ] Mintlify deploy succeeds on this branch
- [ ] Rendered page shows the button labels as `Leave '<your organization>'` and `Delete '<your organization>'` (unchanged visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)