### PR TITLE
docs: document column-level filtering for JWT embedded users

### DIFF
--- a/references/embedding.mdx
+++ b/references/embedding.mdx
@@ -469,7 +469,12 @@ userAttributes?: {
 }
 ```
 
-User attributes filter tables that have `sql_filter` configurations in dbt. See the complete [User attributes guide](/references/workspace/user-attributes).
+The JWT `userAttributes` field drives both row-level and column-level access controls, the same ones available to Lightdash account users:
+
+- **Row-level filtering**: attributes are substituted into any `sql_filter` on the dbt model (e.g. `${lightdash.attributes.tenant_id}`), restricting which rows the embedded user can query.
+- **Column-level filtering**: attributes are matched against [`required_attributes`](/references/workspace/user-attributes#column-filtering-with-required_attributes) and `any_attributes` rules on dimensions, metrics, and tables. Fields whose rules the embedded user's attributes don't satisfy are stripped from the explore entirely: they don't appear in the field list, can't be queried, and return Forbidden if requested directly. Metrics derived from a hidden dimension are hidden too.
+
+See the complete [User attributes guide](/references/workspace/user-attributes).
 
 ## User metadata
 


### PR DESCRIPTION
## Summary
- Updates the `## User attributes` section in `references/embedding.mdx` to clarify that the JWT `userAttributes` field drives both row-level (`sql_filter`) and column-level (`required_attributes` / `any_attributes`) access controls, matching account-user behavior.
- Links to the `required_attributes` anchor in the user attributes guide so embedders can find the full rule syntax.

## Context
- Closes out follow-up from Pylon #13114 (Claudio @ Kraken). Oli confirmed the behavior in the ticket and committed to a docs update.

## Test plan
- [ ] Preview the rendered `references/embedding.mdx` page and confirm the bullets, inline code, and link to `/references/workspace/user-attributes#column-filtering-with-required_attributes` render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)