### PR TITLE
docs: document spaces and nested space slugs in dashboards-as-code

### DIFF
--- a/guides/developer/dashboards-as-code.mdx
+++ b/guides/developer/dashboards-as-code.mdx
@@ -309,48 +309,20 @@ There are detailed instructions within the repo, but the general steps are as fo
 
 Note that these templates still rely on access to an underlying dbt model containing the relevant data, you might need to create or adjust this following the instructions in the [lightdash-templates](https://github.com/lightdash/lightdash-templates) repo.
 
-## Spaces
+## Spaces and sub-spaces
 
-When you upload charts or dashboards as code, the `spaceSlug` field in each YAML file determines which space the content is placed in. You don't need to create spaces in the UI first, the CLI will automatically create any spaces that don't exist when you run `lightdash upload --force`.
+The `spaceSlug` field controls which space content lands in. You don't need to pre-create spaces in the UI: `lightdash upload --force` will create any that don't exist. Slugs are lowercase and hyphenated (e.g. a space named "Data Team" has the slug `data-team`).
 
-### Space slugs
-
-Space slugs are always lowercase and hyphenated. Special characters, uppercase letters, and spaces in the name are converted to hyphens. For example, a space named "Data Team - Product" has the slug `data-team-product`.
-
-### Nested spaces (sub-spaces)
-
-To place content in a sub-space, use a slash-separated path in `spaceSlug` that includes the full hierarchy from root to target:
+To target a sub-space, use a slash-separated path with the full hierarchy from root to target:
 
 ```yaml
 # Places this dashboard in the "Revenue" space under "Management"
 spaceSlug: management/revenue
 ```
 
-Deeper nesting works the same way:
-
-```yaml
-spaceSlug: management/revenue/emea
-```
-
 <Warning>
-If you only use the leaf slug (e.g. `spaceSlug: revenue` instead of `spaceSlug: management/revenue`), the CLI will treat it as a root-level space. If no root space with that slug exists, it will create one at the top level.
+If you only use the leaf slug (e.g. `spaceSlug: revenue` instead of `spaceSlug: management/revenue`), the CLI treats it as a root-level space and will create one at the top level if it doesn't exist.
 </Warning>
-
-### Space definition files
-
-When you run `lightdash download`, the CLI generates `.space.yml` files alongside your chart and dashboard files. These preserve the original display name of each space, including casing, spaces, and emoji.
-
-```yaml
-contentType: space
-spaceName: "Data Team - Product"
-slug: "data-team-product"
-```
-
-When you upload, the CLI reads these files to create spaces with the correct display names. Without them, the CLI derives a name from the slug (e.g. `data-team-product` becomes "Data team product"), which may not match your intended formatting.
-
-<Tip>
-The easiest way to get the right `spaceSlug` format and `.space.yml` files is to create your spaces in the UI first, then run `lightdash download`. The downloaded files will have the correct slugs and display names ready to use.
-</Tip>
 
 ## Dashboard as code yml reference
 

--- a/guides/developer/dashboards-as-code.mdx
+++ b/guides/developer/dashboards-as-code.mdx
@@ -309,6 +309,49 @@ There are detailed instructions within the repo, but the general steps are as fo
 
 Note that these templates still rely on access to an underlying dbt model containing the relevant data, you might need to create or adjust this following the instructions in the [lightdash-templates](https://github.com/lightdash/lightdash-templates) repo.
 
+## Spaces
+
+When you upload charts or dashboards as code, the `spaceSlug` field in each YAML file determines which space the content is placed in. You don't need to create spaces in the UI first, the CLI will automatically create any spaces that don't exist when you run `lightdash upload --force`.
+
+### Space slugs
+
+Space slugs are always lowercase and hyphenated. Special characters, uppercase letters, and spaces in the name are converted to hyphens. For example, a space named "Data Team - Product" has the slug `data-team-product`.
+
+### Nested spaces (sub-spaces)
+
+To place content in a sub-space, use a slash-separated path in `spaceSlug` that includes the full hierarchy from root to target:
+
+```yaml
+# Places this dashboard in the "Revenue" space under "Management"
+spaceSlug: management/revenue
+```
+
+Deeper nesting works the same way:
+
+```yaml
+spaceSlug: management/revenue/emea
+```
+
+<Warning>
+If you only use the leaf slug (e.g. `spaceSlug: revenue` instead of `spaceSlug: management/revenue`), the CLI will treat it as a root-level space. If no root space with that slug exists, it will create one at the top level.
+</Warning>
+
+### Space definition files
+
+When you run `lightdash download`, the CLI generates `.space.yml` files alongside your chart and dashboard files. These preserve the original display name of each space, including casing, spaces, and emoji.
+
+```yaml
+contentType: space
+spaceName: "Data Team - Product"
+slug: "data-team-product"
+```
+
+When you upload, the CLI reads these files to create spaces with the correct display names. Without them, the CLI derives a name from the slug (e.g. `data-team-product` becomes "Data team product"), which may not match your intended formatting.
+
+<Tip>
+The easiest way to get the right `spaceSlug` format and `.space.yml` files is to create your spaces in the UI first, then run `lightdash download`. The downloaded files will have the correct slugs and display names ready to use.
+</Tip>
+
 ## Dashboard as code yml reference
 
 The yml configuration for dashboards as code is extensive. It covers both dashboards and individual charts. The best way to start is often to create your content in the Lightdash UI, download it, and in most cases the structure will be fairly intuitive. Below are outlines of the structures you will find for both types of content to provide some additional context. 


### PR DESCRIPTION
## Summary
- Adds a new `## Spaces` section to `guides/developer/dashboards-as-code.mdx`, placed just before the `## Dashboard as code yml reference` section.
- Covers slug formatting rules, nested sub-space paths via slash-separated `spaceSlug`, the `.space.yml` definition files generated by `lightdash download`, and the gotcha where a leaf-only slug creates a new root-level space.

## Test plan
- [ ] Preview the rendered `guides/developer/dashboards-as-code.mdx` page and confirm the new section, code blocks, `<Warning>`, and `<Tip>` render correctly above the yml reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)