### PR TITLE
docs: mark user impersonation as GA

### DIFF
--- a/references/workspace/user-impersonation.mdx
+++ b/references/workspace/user-impersonation.mdx
@@ -4,9 +4,7 @@ description: "Temporarily view Lightdash as another user to troubleshoot user-sp
 ---
 
 <Info>
-  **This feature is experimental.**
-
-  User impersonation is behind a feature flag. Reach out to support to enable it for your organization. Learn more about [Feature Maturity Levels](/references/workspace/feature-maturity-levels).
+  User impersonation is behind a feature flag. [Contact support](mailto:support@lightdash.com) to enable it for your organization.
 </Info>
 
 User impersonation allows organization admins to temporarily view Lightdash as another user in their organization. This helps troubleshoot user-specific issues like permission problems, data access questions, or UI concerns without requiring the user's credentials.
@@ -16,6 +14,7 @@ User impersonation allows organization admins to temporarily view Lightdash as a
 When you impersonate a user:
 
 - You see Lightdash exactly as that user sees it, including their permissions, spaces, and data access
+- If the project requires users to provide their own warehouse credentials, queries run with the impersonated user's [personal warehouse credentials](/references/workspace/personal-warehouse-connections) (including SSO-backed credentials)
 - A banner appears at the top of the screen indicating you're impersonating someone
 - All actions are logged for audit purposes—Lightdash logs the start and end of each impersonation session, and every request made while impersonating includes both the impersonating admin's `userUuid` and the impersonated user's `userUuid`
 - Each impersonation session has a hard limit of **15 minutes**. After 15 minutes, the session automatically ends and you return to your normal admin view

--- a/references/workspace/user-impersonation.mdx
+++ b/references/workspace/user-impersonation.mdx
@@ -14,11 +14,14 @@ User impersonation allows organization admins to temporarily view Lightdash as a
 When you impersonate a user:
 
 - You see Lightdash exactly as that user sees it, including their permissions, spaces, and data access
-- If the project requires users to provide their own warehouse credentials, queries run with the impersonated user's [personal warehouse credentials](/references/workspace/personal-warehouse-connections) (including SSO-backed credentials)
 - A banner appears at the top of the screen indicating you're impersonating someone
 - All actions are logged for audit purposes—Lightdash logs the start and end of each impersonation session, and every request made while impersonating includes both the impersonating admin's `userUuid` and the impersonated user's `userUuid`
 - Each impersonation session has a hard limit of **15 minutes**. After 15 minutes, the session automatically ends and you return to your normal admin view
 - You can stop impersonation at any time by clicking the button in the banner
+
+<Warning>
+  If the project requires users to provide their own warehouse credentials, queries run with the impersonated user's [personal warehouse credentials](/references/workspace/personal-warehouse-connections) (including SSO-backed credentials).
+</Warning>
 
 ## Who can use impersonation
 


### PR DESCRIPTION
Closes: [GLITCH-341](https://linear.app/lightdash/issue/GLITCH-341/test-user-level-credentials-and-how-they-interact-with-user)

## Description:

User impersonation is now GA. Removes the experimental banner, notes the feature is still behind a flag (admins contact support to enable), and adds a bullet clarifying that when a project requires users to provide their own warehouse credentials, queries run with the impersonated user's personal credentials (including SSO-backed ones).

Callout before/after:

```
Before:
  **This feature is experimental.**
  User impersonation is behind a feature flag. Reach out to
  support to enable it. Learn more about Feature Maturity Levels.

After:
  User impersonation is behind a feature flag.
  Contact support to enable it for your organization.
```