### PR TITLE
docs: update verified content page for shipped AI agent features

### DIFF
--- a/guides/verified-content.mdx
+++ b/guides/verified-content.mdx
@@ -44,6 +44,10 @@ This makes it easy for teams to distinguish between exploratory or work-in-progr
   <img src="/images/guides/verified-content/homepage-tab.png" alt="Homepage with a 'Verified' tab listing all verified charts and dashboards for quick access"/>
 </Frame>
 
+## How the AI agent uses verified content
+
+The in-product Lightdash AI agent ranks admin-verified charts and dashboards first when retrieving content for context, and its system prompt treats verified items as the canonical source of truth for company metrics and patterns. When you ask the agent a question, it will lean on verified examples and prefer fields that already appear in verified charts.
+
 ## Verification is automatically removed when content changes
 
 Verification is tied to the exact state of the content at the time it was verified. If anyone edits a verified chart or dashboard, the verification badge is automatically removed. An admin will need to review the updated version and re-verify it.
@@ -99,7 +103,6 @@ This means CI pipelines run by non-admin deployers (for example, with the `devel
 
 Today, admin-verified charts and dashboards live in a separate stream from [verified answers](/guides/ai-agents/verified-answers) (the AI-agent-generated content that users mark as verified inside an AI agent conversation). We're working on bringing them together so that any verified piece of content, wherever it was verified, is treated as a single trusted signal across:
 
-- The verified badge in tiles, search, the resource browser, and space overviews
-- Content-as-code YAML download/upload
-- The [Lightdash MCP](/references/integrations/lightdash-mcp) `list_verified_content` tool
-- In-product AI agent retrieval and suggestions
+- The `list_verified_content` MCP tool returning AI-verified artifacts alongside admin-verified ones (today it only returns admin-verified)
+- Content-as-code YAML round-trip for AI-verified content (admin-verified content already round-trips; AI-verified is the gap)
+- Using verified content as templates when the AI agent generates new charts and dashboards (basic retrieval shipped, templates is the next step)

--- a/guides/verified-content.mdx
+++ b/guides/verified-content.mdx
@@ -103,6 +103,6 @@ This means CI pipelines run by non-admin deployers (for example, with the `devel
 
 Today, admin-verified charts and dashboards live in a separate stream from [verified answers](/guides/ai-agents/verified-answers) (the AI-agent-generated content that users mark as verified inside an AI agent conversation). We're working on bringing them together so that any verified piece of content, wherever it was verified, is treated as a single trusted signal across:
 
-- The `list_verified_content` MCP tool returning AI-verified artifacts alongside admin-verified ones (today it only returns admin-verified)
-- Content-as-code YAML round-trip for AI-verified content (admin-verified content already round-trips; AI-verified is the gap)
-- Using verified content as templates when the AI agent generates new charts and dashboards (basic retrieval shipped, templates is the next step)
+- The `list_verified_content` MCP tool returning AI-verified artifacts alongside admin-verified ones
+- Content-as-code YAML round-trip for AI-verified content
+- Using verified content as templates when the AI agent generates new charts and dashboards


### PR DESCRIPTION
## Summary
- Add a new "How the AI agent uses verified content" section describing how the in-product agent ranks and treats admin-verified content
- Trim the "Coming soon" bullet list to reflect what has shipped, sharpening the three items still ahead

## Test plan
- [ ] Preview the page renders the new section between "Where users see verified content" and "Verification is automatically removed when content changes"
- [ ] Confirm the updated "Coming soon" list reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)