### PR TITLE
docs: document PAT auth and custom headers for Lightdash MCP

### DIFF
--- a/references/integrations/lightdash-mcp.mdx
+++ b/references/integrations/lightdash-mcp.mdx
@@ -227,8 +227,10 @@ If you're building your own agents or automated workflows, you can integrate dir
 
 - **Transport**: Lightdash MCP exposes a StreamableHTTP transport endpoint at `https://<your_instance_name>.lightdash.cloud/api/v1/mcp`
 - **Debugging**: Use `@modelcontextprotocol/inspector` to inspect and debug the MCP connection
-- **Authentication**: Requires OAuth 2.0 flow for secure authentication
+- **Authentication**: For interactive setups use OAuth 2.0. For headless agents and automated workflows, you can authenticate with a Personal Access Token by passing `Authorization: ApiKey <token>` instead. Create the token under **Settings → Personal access tokens** for the user whose permissions and attributes you want the integration to use. Service account tokens are also supported on plans that include them.
 - **Documentation**: See the [MCP specification](https://modelcontextprotocol.io/docs) for implementation details
+- **Pin a project (optional)**: pass `X-Lightdash-Project: <project-uuid>` to scope the MCP session to a specific project, skipping the `set_project` step.
+- **Override user attributes per request (optional)**: pass `X-Lightdash-User-Attributes: <json>` to override the authenticated user's attributes for that request (useful for row-level security when an agent acts on behalf of different end-users).
 
 {/*<Accordion title="Example: Inspecting the MCP endpoint">
 


### PR DESCRIPTION
## Summary
- Updates the Custom Integration section of the Lightdash MCP reference to note that Personal Access Tokens (and service account tokens, where available) are supported alongside OAuth 2.0.
- Documents the optional `X-Lightdash-Project` and `X-Lightdash-User-Attributes` headers for scoping a session to a project or overriding user attributes per request.

## Test plan
- [ ] Verify the rendered page reads cleanly under **Custom Integration (For Developers)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)