### PR TITLE
docs: update data access default to enabled

### DIFF
--- a/guides/ai-agents/data-access.mdx
+++ b/guides/ai-agents/data-access.mdx
@@ -3,18 +3,11 @@ title: Data access control
 description: Understand how AI agents access and use your data
 ---
 
-AI agents offer flexible data access control to balance insights with privacy and security. By default, agents work with metadata only, but you can optionally enable data access for deeper analysis.
+AI agents offer flexible data access control to balance insights with privacy and security. By default, agents have data access enabled, and you can disable it per agent when you want metadata-only behavior.
 
 ## Data access modes
 
-**Metadata-only mode (default):**
-
-- Agents can see your data structure, field names, and model definitions
-- They can generate appropriate queries and visualizations
-- No actual data values (except for one-row query results) are shared with the agent
-- Perfect for exploring data structure and creating initial analyses
-
-**Data access enabled:**
+**Data access enabled (default):**
 
 - Agents receive actual query results in addition to metadata
 - Can provide specific insights, identify trends, and analyze patterns in your data
@@ -22,14 +15,20 @@ AI agents offer flexible data access control to balance insights with privacy an
 - Can search for actual field values to ensure accurate filters when building visualizations
 - Only shares data when explicitly enabled per agent
 
+**Metadata-only mode:**
+
+- Agents can see your data structure, field names, and model definitions
+- They can generate appropriate queries and visualizations
+- No actual data values (except for one-row query results) are shared with the agent
+- Perfect for exploring data structure and creating initial analyses
+
 <Info>
-  Data access is optional and controlled per agent. When disabled, agents only
-  work with your data model structure and cannot see actual data values. This
-  ensures sensitive information is only shared when you explicitly choose to
-  enable this capability.
+  Data access is controlled per agent and is enabled by default.
+  Turn it off when you want the agent to work only with your data model
+  structure and not see actual data values.
 </Info>
 
-To enable data access, go to your agent settings and toggle the "Data Access" option.
+To change data access, go to your agent settings and toggle the "Data Access" option.
 
   <Frame>
     <img

--- a/guides/ai-agents/getting-started.mdx
+++ b/guides/ai-agents/getting-started.mdx
@@ -103,8 +103,8 @@ The more context you provide, the more accurate, relevant, and predictable your 
 ### Knowledge documents (optional)
 Upload reference material — glossaries, metric definitions, business context, internal SOPs — that your agent can consult while answering questions. Use this for the kind of context that doesn't fit neatly into a dbt `ai_hint` or your instructions. See [knowledge documents best practices](/guides/ai-agents/best-practices#knowledge-documents) for guidance on what to upload.
 
-### Enable Data Access (optional)
-Enable data access to allow your agent to analyze actual query results and provide insights based on the data. When disabled, agents work with metadata only. Learn [how to enable data access](/guides/ai-agents/data-access#how-to-enable-data-access)
+### Data Access
+By default, agents have data access enabled so they can analyze actual query results and provide insights based on the data. You can turn it off per agent if you want metadata-only behavior. Learn more in [data access control](/guides/ai-agents/data-access).
 ### User and Group Access (optional)
 Control which users and groups can access your agent through the agent settings. For detailed guidance on how to configure data access control, see [here](/guides/ai-agents/data-access#user-attributes-and-permissions)
 ### Tags (optional)
@@ -237,4 +237,3 @@ Once a channel is designated as the multi-agent channel, all eligible agents in 
 <Warning>
 If you see the error **"This Slack channel is already assigned to another AI agent"** while trying to attach a second agent via the per-agent integration path, that path only supports single-agent channels. Switch to the org-level multi-agent channel setup described above instead.
 </Warning>
-


### PR DESCRIPTION
Updates the data access documentation to reflect that data access is now **enabled by default** for AI agents, rather than being an opt-in feature.

- Reorders the data access modes so "Data access enabled" appears first as the default, with "Metadata-only mode" listed as the alternative
- Updates the info callout and surrounding copy to reflect the new default behavior
- Adjusts the getting started guide to remove the "optional" label from the Data Access section and clarify that it's on by default with the option to disable it per agent