### PR TITLE
docs: add ai agent content editing guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -155,6 +155,7 @@
                   "guides/ai-agents/data-access",
                   "guides/ai-agents/best-practices",
                   "guides/ai-agents/ai-writeback",
+                  "guides/ai-agents/content-tools",
                   "guides/ai-agents/mcp-servers",
                   "guides/ai-agents/autopilot"
                 ]

--- a/guides/ai-agents.mdx
+++ b/guides/ai-agents.mdx
@@ -46,6 +46,9 @@ This guide covers everything you need to know about AI agents in Lightdash:
   <Card title="AI writeback (Beta)" icon="sparkles" horizontal href="/guides/ai-agents/ai-writeback">
 
   </Card>
+  <Card title="Creating & editing content (Beta)" icon="pen-to-square" horizontal href="/guides/ai-agents/content-tools">
+
+  </Card>
 </CardGroup>
 
 <br />
@@ -68,3 +71,4 @@ This guide covers everything you need to know about AI agents in Lightdash:
 - **Evaluations** - Create test suites to validate your agent’s answers and prevent regressions.
 - **Conversations** - Monitor all agent interactions in one place, review feedback, and build evaluation sets directly from real threads.
 - **AI writeback (Beta)** - Ask an agent to edit your dbt project in chat and open a pull request with the changes
+- **Creating & editing content (Beta)** - Agents can build and edit charts and dashboards on request

--- a/guides/ai-agents/content-tools.mdx
+++ b/guides/ai-agents/content-tools.mdx
@@ -1,0 +1,68 @@
+---
+title: Creating and editing content (Beta)
+sidebarTitle: Creating & editing content
+description: Let AI agents build and edit charts and dashboards in Lightdash
+---
+
+<Info>
+  **Availability:** Content editing is a [Beta](/references/workspace/feature-maturity-levels) feature. Enable it for a specific agent when you are ready for that agent to create and update saved Lightdash content.
+</Info>
+
+By default, AI agents answer questions and propose visualizations without changing your saved charts and dashboards. When content editing is enabled, an agent can also save new content and update existing content when you ask it to.
+
+## What agents can do
+
+When content editing is enabled, your agent can:
+
+**Create saved content:**
+
+- Build a new chart from a question and save it to a space
+- Build a new dashboard from scratch, following Lightdash dashboard best practices for chart choice, layout, filters, tabs, and supporting detail
+- Add charts, headings, filters, and tabs to a new or existing dashboard
+
+**Edit existing content:**
+
+- Add, remove, or rearrange tiles on a dashboard
+- Organize a dashboard into tabs
+- Add or change dashboard filters
+- Update a chart's fields, filters, or visualization
+- Rename content or update its description
+- Move charts and dashboards to another space
+
+## Spaces
+
+Content created by an agent is saved in a Lightdash space, just like content created from the Explore page or dashboard editor. Tell the agent which space to use when you want the content saved somewhere specific. If you do not name a space, the agent can choose the best match from the spaces it has access to.
+
+The agent's access is limited by its [space access](/guides/ai-agents/getting-started). If the agent cannot access a space, it cannot create, edit, or move content there.
+
+For example, ask the agent to "add this chart to the Revenue dashboard", "move this dashboard to the Finance space", or "create an executive sales dashboard in the Leadership space".
+
+## Permissions
+
+Content editing is available only when all of these are true:
+
+1. **The agent has content editing enabled.** This is a setting on each agent.
+2. **The requesting user has permission to use dashboards as code.** This is included for admins and developers.
+
+Turning the setting on does not give viewers or interactive viewers new permissions. If they ask the agent to create or edit saved content, the agent will not have those tools available.
+
+<Info>
+**In the Lightdash app:** the logged-in user's permissions are used for every request.
+
+**In Slack:** By default, an agent acts as the user who created it. To evaluate each Slack user's own permissions, enable the **AI Agents OAuth requirement** toggle in your [Lightdash Slack settings](/references/integrations/slack-integration#ai-agents-configuration). Until a Slack user connects their Slack account to Lightdash, content editing stays disabled for them.
+</Info>
+
+## Enabling content editing
+
+Only admins and developers can enable content editing for an agent:
+
+1. Go to your agent settings
+2. Toggle **Allow agent to manage Lightdash content**
+3. Save your changes
+
+## Reviewing changes
+
+Content an agent creates or edits is saved like any other chart or dashboard, with the agent recorded as the editor. Because changes are saved immediately, treat content editing as you would any contributor with edit access:
+
+- Scope each agent with [space access](/guides/ai-agents/getting-started) so it can only work in the spaces you intend
+- Use [version history](/guides/version-history) on a chart or dashboard to review or revert an agent's edits


### PR DESCRIPTION
## Summary
- Add a beta guide for AI agent content editing
- Document creating, editing, moving, permissions, Slack identity, and review flows
- Add the guide to the AI agents navigation and overview

## Testing
- Not run: no local docs validation script/config found