### PR TITLE
fix: ignore draft docs in link checker

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -30,10 +30,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'pnpm'
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Post initial status comment
         id: initial-comment

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iws
 .idea_modules/
 out/
+node_modules/
 images/.DS_Store
 .DS_Store
 .env/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=3

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mintlify-docs",
+  "version": "1.0.0",
+  "description": "Lightdash documentation",
+  "private": true,
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lightdash/mintlify-docs.git"
+  },
+  "type": "commonjs",
+  "dependencies": {
+    "gray-matter": "^4.0.3"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,91 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+
+packages:
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  esprima@4.0.1: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  is-extendable@0.1.1: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  kind-of@6.0.3: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  sprintf-js@1.0.3: {}
+
+  strip-bom-string@1.0.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -8,6 +8,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const matter = require('gray-matter');
 
 const CHECK_EXTERNAL = process.argv.includes('--external');
 
@@ -39,6 +40,11 @@ function findMDXFiles(dir, fileList = []) {
   });
 
   return fileList;
+}
+
+function hasDraftTitle(content) {
+  const title = matter(content).data.title;
+  return typeof title === 'string' && title.toLowerCase().includes('draft');
 }
 
 function extractLinks(content, filePath) {
@@ -282,9 +288,13 @@ async function main() {
 
   const mdxFiles = findMDXFiles('.');
   const excludedPaths = ['node_modules', '.git', 'CONTRIBUTING.md'];
-  const filteredFiles = mdxFiles.filter(file =>
-    !excludedPaths.some(excluded => file.includes(excluded))
-  );
+  const filteredFiles = mdxFiles.filter(file => {
+    if (excludedPaths.some(excluded => file.includes(excluded))) {
+      return false;
+    }
+
+    return !hasDraftTitle(fs.readFileSync(file, 'utf8'));
+  });
 
   const brokenLinks = [];
   const externalLinks = [];

--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Working with timezones in Lightdash"
+title: "Draft: Working with timezones in Lightdash"
 description: "Hidden draft: how to model warehouse data and use Lightdash so that timezones behave predictably."
 hidden: true
 ---


### PR DESCRIPTION
## Summary
- Add a minimal pnpm project with `gray-matter` for frontmatter parsing
- Use the same pnpm SFW settings as `../lightdash`: exact save mode plus a 3-day/minimum-release-age install cooldown
- Skip MDX/Markdown files whose frontmatter title contains `draft` when running the link checker
- Mark the timezone draft title as a draft so it is ignored by the checker
- Install pnpm dependencies in the docs validation workflow before running Node scripts

## Testing
- `pnpm install`
- `pnpm install --frozen-lockfile`
- `node scripts/check-links.js`

## Tracking
- No Linear ticket provided