### PR TITLE
[codex] Add docs PR assignment workflow

### DIFF
--- a/.github/workflows/assign-docs-pr.yml
+++ b/.github/workflows/assign-docs-pr.yml
@@ -1,0 +1,110 @@
+name: Assign Docs PR
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-docs-pr:
+    name: Assign docs PR to source PR author
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'mintlify[bot]'
+
+    steps:
+      - name: Assign source PR author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const docsPr = context.payload.pull_request;
+            const body = docsPr.body || '';
+            const sourceMatch = body.match(/lightdash\/lightdash(?:#|\/pull\/)(\d+)/i);
+            const contextualSourceMatch = body.match(/(?:upstream PR|source PR|triggered by|follows|follow-up to)[^#]{0,120}#(\d{5,})/is);
+            let sourcePrNumber = sourceMatch ? Number(sourceMatch[1]) : undefined;
+            let sourceReason = sourceMatch ? 'body source reference' : undefined;
+
+            if (!sourcePrNumber && contextualSourceMatch) {
+              sourcePrNumber = Number(contextualSourceMatch[1]);
+              sourceReason = 'body contextual source reference';
+            }
+
+            if (!sourcePrNumber) {
+              const { data: events } = await github.rest.issues.listEventsForTimeline({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: docsPr.number,
+                per_page: 100,
+              });
+
+              const sourceEvent = [...events].reverse().find((event) => (
+                event.event === 'cross-referenced' &&
+                event.source?.issue?.repository?.full_name === 'lightdash/lightdash' &&
+                event.source?.issue?.pull_request
+              ));
+
+              if (sourceEvent) {
+                sourcePrNumber = sourceEvent.source.issue.number;
+                sourceReason = 'timeline cross-reference';
+              }
+            }
+
+            if (!sourcePrNumber) {
+              core.info('No lightdash/lightdash source PR found.');
+              return;
+            }
+
+            const { data: sourcePr } = await github.rest.pulls.get({
+              owner: 'lightdash',
+              repo: 'lightdash',
+              pull_number: sourcePrNumber,
+            });
+
+            const author = sourcePr.user?.login;
+            if (!author) {
+              core.info(`Source PR #${sourcePrNumber} has no author. Skipping assignment.`);
+              return;
+            }
+
+            if (author.endsWith('[bot]')) {
+              core.info(`Source PR #${sourcePrNumber} author is ${author}. Skipping bot assignment.`);
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: docsPr.number,
+              assignees: [author],
+            });
+
+            const wasAssigned = issue.assignees?.some((assignee) => assignee.login === author);
+            if (wasAssigned) {
+              core.info(`Assigned docs PR #${docsPr.number} to ${author} via ${sourceReason}.`);
+              return;
+            }
+
+            const fallbackBody = `cc @${author}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: docsPr.number,
+              per_page: 100,
+            });
+
+            const hasFallback = comments.some((comment) => comment.body?.trim() === fallbackBody);
+            if (hasFallback) {
+              core.info(`Assignment did not land, but fallback comment already exists for ${author}.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: docsPr.number,
+              body: fallbackBody,
+            });
+
+            core.info(`Assignment did not land for ${author}. Posted fallback cc comment.`);

--- a/.github/workflows/assign-docs-pr.yml
+++ b/.github/workflows/assign-docs-pr.yml
@@ -32,7 +32,7 @@ jobs:
             }
 
             if (!sourcePrNumber) {
-              const { data: events } = await github.rest.issues.listEventsForTimeline({
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: docsPr.number,
@@ -51,25 +51,50 @@ jobs:
               }
             }
 
-            if (!sourcePrNumber) {
-              core.info('No lightdash/lightdash source PR found.');
-              return;
+            // Resolve the author to assign: prefer the source PR author, then fall
+            // back to an explicit `cc @author` mention in the docs PR body.
+            let author;
+            let reason;
+
+            if (sourcePrNumber) {
+              let sourcePr;
+              try {
+                ({ data: sourcePr } = await github.rest.pulls.get({
+                  owner: 'lightdash',
+                  repo: 'lightdash',
+                  pull_number: sourcePrNumber,
+                }));
+              } catch (error) {
+                core.info(`Could not load lightdash/lightdash#${sourcePrNumber} (${error.status || error.message}). Falling back to cc mention.`);
+              }
+
+              const sourceAuthor = sourcePr?.user?.login;
+              if (sourcePr && !sourceAuthor) {
+                core.info(`Source PR #${sourcePrNumber} has no author.`);
+              } else if (sourceAuthor?.endsWith('[bot]')) {
+                core.info(`Source PR #${sourcePrNumber} author is ${sourceAuthor}. Skipping bot assignment.`);
+                return;
+              } else if (sourceAuthor) {
+                author = sourceAuthor;
+                reason = sourceReason;
+              }
             }
 
-            const { data: sourcePr } = await github.rest.pulls.get({
-              owner: 'lightdash',
-              repo: 'lightdash',
-              pull_number: sourcePrNumber,
-            });
-
-            const author = sourcePr.user?.login;
             if (!author) {
-              core.info(`Source PR #${sourcePrNumber} has no author. Skipping assignment.`);
-              return;
+              const ccMatch = body.match(/(?:^|\n)\s*cc\s+@([A-Za-z0-9-]+)/i);
+              if (ccMatch) {
+                const ccAuthor = ccMatch[1];
+                if (ccAuthor.endsWith('[bot]')) {
+                  core.info(`cc mention is bot @${ccAuthor}. Skipping.`);
+                } else {
+                  author = ccAuthor;
+                  reason = 'cc mention';
+                }
+              }
             }
 
-            if (author.endsWith('[bot]')) {
-              core.info(`Source PR #${sourcePrNumber} author is ${author}. Skipping bot assignment.`);
+            if (!author) {
+              core.info('No lightdash/lightdash source PR author or cc mention found.');
               return;
             }
 
@@ -82,7 +107,7 @@ jobs:
 
             const wasAssigned = issue.assignees?.some((assignee) => assignee.login === author);
             if (wasAssigned) {
-              core.info(`Assigned docs PR #${docsPr.number} to ${author} via ${sourceReason}.`);
+              core.info(`Assigned docs PR #${docsPr.number} to ${author} via ${reason}.`);
               return;
             }
 

--- a/scripts/backfill-docs-pr-assignees.sh
+++ b/scripts/backfill-docs-pr-assignees.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-1}"
+DOCS_REPO="${DOCS_REPO:-lightdash/mintlify-docs}"
+SOURCE_REPO="${SOURCE_REPO:-lightdash/lightdash}"
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  fi
+}
+
+resolve_source_from_text() {
+  perl -0777 -ne 'if (/lightdash\/lightdash(?:#|\/pull\/)(\d+)/i) { print $1; exit } elsif (/(?:upstream PR|source PR|triggered by|follows|follow-up to)[^#]{0,120}#(\d{5,})/is) { print $1; exit }'
+}
+
+resolve_cc_from_text() {
+  perl -0777 -ne 'if (/(?:^|\n)\s*cc\s+@([A-Za-z0-9-]+)/i) { print $1; exit }'
+}
+
+source_pr_author() {
+  local source_number="$1"
+
+  gh api "repos/$SOURCE_REPO/pulls/$source_number" --jq '.user.login // empty'
+}
+
+timeline_source_pr() {
+  local pr_number="$1"
+
+  gh api "repos/$DOCS_REPO/issues/$pr_number/timeline" --paginate --jq \
+    "map(select(.event == \"cross-referenced\" and .source.issue.repository.full_name == \"$SOURCE_REPO\" and .source.issue.pull_request != null)) | .[-1].source.issue.number // empty"
+}
+
+assign_or_comment() {
+  local pr_number="$1"
+  local author="$2"
+
+  local response
+  response="$(gh api -X POST "repos/$DOCS_REPO/issues/$pr_number/assignees" -f "assignees[]=$author")"
+
+  if printf "%s" "$response" | jq -e --arg author "$author" '.assignees // [] | any(.login == $author)' >/dev/null; then
+    return 0
+  fi
+
+  local fallback_body="cc @$author"
+  local has_fallback
+  has_fallback="$(gh api "repos/$DOCS_REPO/issues/$pr_number/comments" --paginate --jq \
+    "any(.[]; (.body // \"\" | ltrimstr(\" \") | rtrimstr(\" \")) == \"$fallback_body\")")"
+
+  if [[ "$has_fallback" == "true" ]]; then
+    return 1
+  fi
+
+  gh pr comment "$pr_number" -R "$DOCS_REPO" --body "$fallback_body" >/dev/null
+  return 1
+}
+
+require_command gh
+require_command jq
+require_command perl
+
+prs_json="$(gh pr list -R "$DOCS_REPO" --state open --limit 200 --json number,title,body,assignees,url)"
+count="$(printf "%s" "$prs_json" | jq 'length')"
+
+echo "Found $count open PRs in $DOCS_REPO"
+echo "Scanning open unassigned PRs only with DRY_RUN=$DRY_RUN"
+
+printf "%s" "$prs_json" | jq -c '.[] | select((.assignees | length) == 0)' | while IFS= read -r pr; do
+  number="$(printf "%s" "$pr" | jq -r '.number')"
+  title="$(printf "%s" "$pr" | jq -r '.title')"
+  body="$(printf "%s" "$pr" | jq -r '.body // ""')"
+  source_number="$(printf "%s" "$body" | resolve_source_from_text)"
+  reason=""
+
+  if [[ -n "$source_number" ]]; then
+    reason="body source reference"
+  else
+    source_number="$(timeline_source_pr "$number")"
+    if [[ -n "$source_number" ]]; then
+      reason="timeline cross-reference"
+    fi
+  fi
+
+  if [[ -n "$source_number" ]]; then
+    author="$(source_pr_author "$source_number")"
+
+    if [[ -z "$author" ]]; then
+      echo "SKIP PR #$number: $SOURCE_REPO#$source_number has no author: $title"
+      continue
+    fi
+
+    if [[ "$author" == *"[bot]" ]]; then
+      echo "SKIP PR #$number: $SOURCE_REPO#$source_number author is bot $author: $title"
+      continue
+    fi
+
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "DRY RUN PR #$number: would assign @$author from $SOURCE_REPO#$source_number via $reason: $title"
+    elif assign_or_comment "$number" "$author"; then
+      echo "ASSIGNED PR #$number to @$author from $SOURCE_REPO#$source_number via $reason: $title"
+    else
+      echo "FALLBACK PR #$number: assignment to @$author did not stick, fallback cc exists or was posted: $title"
+    fi
+
+    continue
+  fi
+
+  cc_author="$(printf "%s" "$body" | resolve_cc_from_text)"
+  if [[ -n "$cc_author" ]]; then
+    if [[ "$cc_author" == *"[bot]" ]]; then
+      echo "SKIP PR #$number: cc mention is bot @$cc_author: $title"
+      continue
+    fi
+
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "DRY RUN PR #$number: would assign @$cc_author from cc mention: $title"
+    elif assign_or_comment "$number" "$cc_author"; then
+      echo "ASSIGNED PR #$number to @$cc_author from cc mention: $title"
+    else
+      echo "FALLBACK PR #$number: assignment to @$cc_author did not stick, fallback cc exists or was posted: $title"
+    fi
+
+    continue
+  fi
+
+  echo "SKIP PR #$number: no source PR or cc mention found: $title"
+done


### PR DESCRIPTION
## Summary

Adds automation to assign Mintlify docs PRs to the engineer who authored the related `lightdash/lightdash` source PR.

## Changes

- Add `.github/workflows/assign-docs-pr.yml` using `actions/github-script@v7`.
- Guard the workflow to Mintlify PRs using the confirmed event login `mintlify[bot]`.
- Parse source PR references from PR bodies, look up the source author, skip bot authors, assign the docs PR, and post `cc @author` if GitHub silently rejects the assignee.
- Add `scripts/backfill-docs-pr-assignees.sh` with `DRY_RUN=1` default behavior for one-off or future backfills.

## Validation

- `bash -n scripts/backfill-docs-pr-assignees.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/assign-docs-pr.yml"); puts "workflow yaml ok"'`
- Ran the backfill against open unassigned PRs after dry-run confirmation. All assignable PRs were assigned, and only PRs with no source owner clue remained unassigned.