### PR TITLE
docs: note CLI version should match UI version in timezones guide

### DIFF
--- a/guides/developer/timezones.mdx
+++ b/guides/developer/timezones.mdx
@@ -40,6 +40,8 @@ Lightdash has two separate timezone settings that solve different problems at di
 
 <Info>
   **Beta:** Several features on this page are currently in the [Beta](/references/workspace/feature-maturity-levels) phase. Contact support to enable them for your organization - each section below is marked accordingly. Without them, the project query timezone only adjusts relative date filter boundaries; everything else renders the raw warehouse value.
+
+  To use these features, make sure your Lightdash CLI version matches the version of Lightdash you see in the UI (scroll to the bottom of your screen to find it). Check yours with `lightdash --version` and see [How to upgrade the CLI](/guides/cli/how-to-upgrade-cli) if it's behind.
 </Info>
 
 ### How the project query timezone is resolved


### PR DESCRIPTION
Adds a note to the top-level Beta callout in the timezones guide stating that, because several timezone features are recent, the Lightdash CLI version should match the version of Lightdash shown in the UI - with a pointer to `lightdash --version` and a link to the CLI upgrade guide.

The wording mirrors the existing guidance in [Upgrading your Lightdash CLI](https://docs.lightdash.com/guides/cli/how-to-upgrade-cli).