### PR TITLE
docs: add ClickHouse boolean column known issue

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -702,6 +702,50 @@ The number of times Lightdash should retry ClickHouse queries that result in unh
 
 This controls what day is the start of the week in Lightdash. `Auto` sets it to whatever the default is for your data warehouse. Or, you can customize it and select the day of the week from the drop-down menu. This will be taken into account when using 'WEEK' time interval in Lightdash.
 
+#### Known issues
+
+##### Boolean expression columns must be typed as boolean
+
+ClickHouse represents the result of boolean expressions, like `status = 'active'`, as `UInt8`. If the column is not typed as boolean in your dbt schema, Lightdash may treat it as a string dimension and generate a filter like `IN ('true')`. ClickHouse rejects this with an error like `Cannot convert string 'true' to type UInt8`. See [GitHub issue #24028](https://github.com/lightdash/lightdash/issues/24028).
+
+To avoid this, explicitly type boolean expression columns as `boolean` in your dbt schema:
+
+```yaml
+models:
+  - name: orders
+    columns:
+      - name: is_active
+        data_type: boolean
+```
+
+Or set the Lightdash dimension type:
+
+<Tabs>
+  <Tab title="dbt v1.9 and earlier">
+    ```yaml
+    models:
+      - name: orders
+        columns:
+          - name: is_active
+            meta:
+              dimension:
+                type: boolean
+    ```
+  </Tab>
+  <Tab title="dbt v1.10+ and Fusion">
+    ```yaml
+    models:
+      - name: orders
+        columns:
+          - name: is_active
+            config:
+              meta:
+                dimension:
+                  type: boolean
+    ```
+  </Tab>
+</Tabs>
+
 ***
 
 <a id="duckdb"></a>


### PR DESCRIPTION
Adds a "Known issues" section to the ClickHouse connection documentation covering a type mismatch that occurs when boolean expression columns are not explicitly typed as `boolean` in the dbt schema. ClickHouse returns `UInt8` for boolean expressions, which can cause Lightdash to treat the column as a string and generate filters that ClickHouse rejects. The section explains the root cause, links to the related GitHub issue, and provides YAML examples showing how to fix it using either `data_type: boolean` or the Lightdash `dimension.type` meta field, with separate tabs for dbt v1.9 and earlier versus dbt v1.10+ and Fusion.