### PR TITLE
docs: document settings in global search results

### DIFF
--- a/get-started/exploring-data/exploring-your-content.mdx
+++ b/get-started/exploring-data/exploring-your-content.mdx
@@ -31,7 +31,7 @@ If you already know what you're looking for, you can use the search bar to searc
   <img src="/images/get-started/exploring-data/exploring-your-content/search-bar-199ebd366ff2bc7d0d209a3f85327786.gif" alt="" />
 </Frame>
 
-This global search feature matches content from everywhere in the project. You can search for dashboards, charts, spaces, tables, and fields by their names and descriptions. It is now more powerful, with the ability to filter results and group them for easier navigation.
+This global search feature matches content from everywhere in the project. You can search for dashboards, charts, spaces, tables, and fields by their names and descriptions, as well as settings pages. It is now more powerful, with the ability to filter results and group them for easier navigation.
 
 ### Search filters
 

--- a/guides/keyboard-shortcuts.mdx
+++ b/guides/keyboard-shortcuts.mdx
@@ -18,7 +18,7 @@ This shortcut works throughout the Lightdash application.
 
 | Shortcut     | Action        | Description                                                             |
 | ------------ | ------------- | ----------------------------------------------------------------------- |
-| Cmd/Ctrl + K | Global search | Open the global search to quickly find charts, dashboards, and explores |
+| Cmd/Ctrl + K | Global search | Open the global search to quickly find charts, dashboards, explores, and settings |
 
 ## Query from tables shortcuts
 


### PR DESCRIPTION
Settings pages are now a result type in global search, reachable from both the settings sidebar and the omni bar (`Cmd/Ctrl + K`). The docs previously only listed charts, dashboards, spaces, tables, and fields, so this updates the two places that enumerate what search returns.

What changed in the docs:

  Before:
    "Using the search bar" → dashboards, charts, spaces, tables, fields
    Cmd/Ctrl + K shortcut  → "find charts, dashboards, and explores"

  After:
    "Using the search bar" → ...fields, as well as settings pages
    Cmd/Ctrl + K shortcut  → "...explores, and settings"

Files:
- `get-started/exploring-data/exploring-your-content.mdx` — added settings to the search result types.
- `guides/keyboard-shortcuts.mdx` — updated the global search shortcut description.

The settings-internal search box is intentionally left undocumented — there's no settings-UI overview page to host it, and it's a minor UX nicety.

Verified the rendered prose reads cleanly in both edited sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)