### PR TITLE
docs(sankey): document the node layout options

### DIFF
--- a/references/chart-types/sankey.mdx
+++ b/references/chart-types/sankey.mdx
@@ -59,7 +59,16 @@ Unlike traditional Sankey implementations, Lightdash supports cyclical data wher
 
 The chart handles these cycles by creating step-suffixed node instances (e.g., "Conversion - Step 2").
 
+### Node layout
+
+The **Node layout** option controls how a label that appears at more than one depth is rendered. For funnels where a single stage is reached from several preceding steps, the default can make one real stage look like several different nodes, so you can choose between three layouts:
+
+- **Multi-step** (default) — Each occurrence of a label at a different depth is rendered as a separate node, including cycles, which become "Step N" instances as described above. This preserves the full journey.
+- **Merged** — Collapses nodes that share a label into a single node, so all flows in and out of that label converge on one node while the multi-step journey is preserved. Available for acyclic flows only; when your data contains a loop the option is disabled and the chart falls back to multi-step.
+- **Direct** — Shows only direct source → target flows in two columns, with no multi-step chaining. A label that is both a source and a target appears once on each side. This works for any data, including cyclical flows.
+
 ## Display options
 
 - **Orientation** — Display flows horizontally (left to right) or vertically (top to bottom)
 - **Node alignment** — Align nodes to the left, right, or justify across the chart
+- **Node layout** — Choose how nodes are arranged: **Multi-step** (depth-based journeys, the default), **Merged** (one node per label, acyclic flows only), or **Direct** (two-column source → target only)


### PR DESCRIPTION
Documents the new **Node layout** option for Sankey charts.

Reworks the Sankey reference to describe the three layouts — **Multi-step** (default), **Merged**, and **Direct** — including the acyclic-only constraint on merging and that Direct works for any data (including cyclical flows). Updates the Display options list accordingly.

Pairs with the feature PR: lightdash/lightdash#24085

Relates: PROD-7963
Relates: PROD-7057