### PR TITLE
docs: update GCS bucket access configuration

### DIFF
--- a/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage.mdx
+++ b/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage.mdx
@@ -20,10 +20,11 @@ Go into GCP: Cloud storage
 
 Create a new bucket with the following details:
 
-- give it an unique `Bucket name` like - `lightdash-cloud-file-storage-eu`
+- Give it an unique `Bucket name` like - `lightdash-cloud-file-storage-eu`
 - Select region (like multi US or multi EU or single region EU-west-1)
-- select storage class: default standard
-- disable `enforce public access` and select `fine-grained`
+- Select storage class: default standard
+- Enable `Enforce public access prevention on this bucket`
+- Select `Uniform` access control
 - Protection: `none`
 
 Go to settings \> Interoperability and create a `Access key for service account`


### PR DESCRIPTION
Fixes incorrect GCS bucket configuration instructions for public access prevention and access control settings. The previous guidance incorrectly advised disabling public access enforcement and using fine-grained access control. The corrected instructions keep public access prevention enabled and use Uniform bucket-level access, which aligns with GCS security best practices.