### PR TITLE
docs: clarify SSO verified domain requirement

### DIFF
--- a/references/workspace/sso-providers.mdx
+++ b/references/workspace/sso-providers.mdx
@@ -11,6 +11,10 @@ Lightdash supports multiple SSO providers for secure authentication. This page p
   <Tab title="Lightdash Cloud">
     If you're on **Lightdash Cloud**, organization admins configure SSO directly from **Organization settings → Single Sign-On** — no environment variables, and no need to involve the Lightdash team. See [Configure SSO](/references/workspace/configure-sso) for the full self-serve setup.
 
+    <Warning>
+      Saving provider credentials is not enough to make SSO available during sign-in. Your organization must also have at least one [verified domain](/references/workspace/verified-domains); otherwise users on that domain will keep seeing the default login options.
+    </Warning>
+
     <Note>
       When following the provider setup guides below, you can skip any steps about setting environment variables — those only apply to self-hosted instances. Focus on the provider-side configuration (creating the OAuth app, redirect URIs, etc.), then enter the resulting values in **Organization settings → Single Sign-On**.
     </Note>

--- a/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -7,6 +7,8 @@ sidebarTitle: SSO and auth
 🛠 This page is for engineering teams **self-hosting** their own Lightdash instance. The environment variables listed below are set directly in your self-hosted deployment.
 
 **Lightdash Cloud users**: configure SSO yourself from **Organization settings → Single Sign-On** — see [Configure SSO](/references/workspace/configure-sso). Use the provider-side steps on this page (creating an OAuth app, configuring redirect URIs, etc.) to obtain the values, then enter them in the organization settings UI instead of setting environment variables.
+
+Cloud SSO also requires a [verified domain](/references/workspace/verified-domains). Saving provider credentials without a verified domain will not route users to that provider during sign-in.
 </Note>
 
 ## Multiple authentication methods
@@ -95,6 +97,8 @@ If you're using a custom authorization server ID:
 
 <Tip>
   **Lightdash Cloud users**: instead of setting these environment variables, enter the client ID, client secret, Okta domain, and issuer URI in **Organization settings → Single Sign-On → Okta**. See [Configure SSO](/references/workspace/configure-sso#okta).
+
+  Make sure your organization has a [verified domain](/references/workspace/verified-domains), otherwise Okta will not appear for users during sign-in.
 </Tip>
 
 You'll need to set the following environment variables in your Lightdash deployment:
@@ -173,6 +177,8 @@ To create a One Login integration:
 
 <Tip>
   **Lightdash Cloud users**: instead of setting these environment variables, enter the client ID, client secret, and issuer URL in **Organization settings → Single Sign-On → OneLogin**. See [Configure SSO](/references/workspace/configure-sso#onelogin).
+
+  Make sure your organization has a [verified domain](/references/workspace/verified-domains), otherwise OneLogin will not appear for users during sign-in.
 </Tip>
 
 These variables enable you to control Single Sign On (SSO) functionality for One Login
@@ -202,6 +208,8 @@ In the left hand menu, navigate to **Certificates & secrets** and click **New cl
 
 <Tip>
   **Lightdash Cloud users**: instead of setting these environment variables, enter the client ID, client secret, and tenant ID in **Organization settings → Single Sign-On → Azure AD**. See [Configure SSO](/references/workspace/configure-sso#azure-active-directory).
+
+  Make sure your organization has a [verified domain](/references/workspace/verified-domains), otherwise Azure AD will not appear for users during sign-in.
 </Tip>
 
 These variables enable you to control Single Sign On (SSO) functionality for Azure Active Directory.
@@ -225,6 +233,8 @@ Lightdash supports OpenID Connect-compliant SSO providers, via our configurable 
 
 <Tip>
   **Lightdash Cloud users**: instead of setting these environment variables, enter the client ID, client secret, and metadata document URL in **Organization settings → Single Sign-On → OpenID Connect**. See [Configure SSO](/references/workspace/configure-sso#openid-connect).
+
+  Make sure your organization has a [verified domain](/references/workspace/verified-domains), otherwise OpenID Connect will not appear for users during sign-in.
 </Tip>
 
 These variables enable you to control Single Sign On (SSO) functionality for a generic OpenID Connect provider.


### PR DESCRIPTION
## Summary
- Add a Cloud SSO warning that provider credentials do not route users until a domain is verified
- Repeat the verified-domain prerequisite in Cloud-user callouts on the self-hosted provider setup guide

## Testing
- Not run, docs-only change

No ticket