### PR TITLE
docs: document per-provider SUPPORTS_STREAMING env vars for non-streaming LLM gateways

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -391,6 +391,7 @@ To enable AI Analyst, set `AI_COPILOT_ENABLED=true` and provide an API key for `
 | `OPENAI_AVAILABLE_MODELS` | Comma-separated list of models available in the model picker (default=All supported models) |
 | `OPENAI_ZERO_DATA_RETENTION` | Sets the OpenAI `OpenAI-Beta: assistants-zdr` header so prompts and completions are not retained by OpenAI. (default=false) |
 | `OPENAI_CUSTOM_HEADERS`  | JSON object of extra HTTP headers to send with every OpenAI request                          |
+| `OPENAI_SUPPORTS_STREAMING` | Set to `false` if the endpoint behind `OPENAI_BASE_URL` (e.g. an LLM gateway) doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
 <Tip>
 **Using an OpenAI-compatible proxy (e.g. LiteLLM)**
@@ -405,6 +406,8 @@ If your organization uses an OpenAI-compatible proxy like [LiteLLM](https://www.
 Make sure your proxy has the model names correctly mapped. For example, if you set `OPENAI_MODEL_NAME=gpt-4o`, your proxy needs to have that model routed to whatever underlying provider you're using. The same applies for the embedding model.
 
 If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_MODELS` with a comma-separated list of model names.
+
+If your proxy or gateway doesn't support streaming (SSE) completions, also set `OPENAI_SUPPORTS_STREAMING=false`. Lightdash will then make a single non-streaming request per model call — the AI agent keeps working unchanged, including the chat UI. Note that while a response is generating no bytes flow through the connection, so make sure any reverse proxy in the path has a read/idle timeout above your longest completion time.
 </Tip>
 
 #### Anthropic Configuration
@@ -415,6 +418,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 | `ANTHROPIC_MODEL_NAME`           | Anthropic model name to use (default=claude-sonnet-4-5)                                     |
 | `ANTHROPIC_AVAILABLE_MODELS`     | Comma-separated list of models available in the model picker (default=All supported models) |
 | `ANTHROPIC_CUSTOM_HEADERS`       | JSON object of extra HTTP headers to send with every Anthropic request                       |
+| `ANTHROPIC_SUPPORTS_STREAMING`   | Set to `false` if your Anthropic endpoint or gateway doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 | `AI_WRITEBACK_ANTHROPIC_API_KEY` | (Required for AI writeback) Dedicated Anthropic API key used by the AI writeback feature. Kept separate from `ANTHROPIC_API_KEY` so writeback and AI Analyst have independent spend caps and fail independently. |
 
 #### Azure AI Configuration
@@ -429,6 +433,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 | `AZURE_USE_DEPLOYMENT_BASED_URLS` | Use deployment-based URLs for Azure OpenAI API calls (default=true)        |
 | `AZURE_AI_DEPLOYMENT_SUPPORTS_REASONING` | Set to `true` if your Azure deployment exposes a reasoning-capable model (e.g. `o3`). Enables reasoning-mode prompts. (default=false) |
 | `AZURE_AI_CUSTOM_HEADERS`        | JSON object of extra HTTP headers to send with every Azure AI request                       |
+| `AZURE_AI_SUPPORTS_STREAMING`    | Set to `false` if your Azure AI endpoint or gateway doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
 #### OpenRouter Configuration
 
@@ -439,6 +444,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 | `OPENROUTER_SORT_ORDER`        | Provider sorting method (`price`, `throughput`, `latency`) (default=latency)                 |
 | `OPENROUTER_ALLOWED_PROVIDERS` | Comma-separated list of allowed providers (`anthropic`, `openai`, `google`) (default=openai) |
 | `OPENROUTER_CUSTOM_HEADERS`    | JSON object of extra HTTP headers to send with every OpenRouter request                      |
+| `OPENROUTER_SUPPORTS_STREAMING` | Set to `false` if your OpenRouter endpoint or gateway doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
 #### AWS Bedrock Configuration
 
@@ -454,6 +460,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 | `BEDROCK_AVAILABLE_MODELS`  | Comma-separated list of models available in the model picker (default=All supported models)  |
 | `BEDROCK_INFERENCE_PROFILE_PREFIX` | Optional prefix prepended to Bedrock model IDs to target a cross-region inference profile (e.g. `us`, `eu`). Overrides the default region-based prefix derived from `BEDROCK_REGION`. |
 | `BEDROCK_CUSTOM_HEADERS`    | JSON object of extra HTTP headers to send with every Bedrock request                         |
+| `BEDROCK_SUPPORTS_STREAMING` | Set to `false` if your Bedrock endpoint or gateway doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
 #### Supported Models
 


### PR DESCRIPTION
Documents the new per-provider `*_SUPPORTS_STREAMING` env vars shipped in lightdash/lightdash#24129, which let the AI agent run behind LLM gateways that don't support streaming (SSE) completions.

What changed in the docs (`self-host/customize-deployment/environment-variables.mdx`):

- Added a `<PROVIDER>_SUPPORTS_STREAMING` row (default `true`) to each of the five AI provider tables: OpenAI, Anthropic, Azure AI, OpenRouter, and Bedrock.
- Extended the "OpenAI-compatible proxy" tip: how to combine the flag with `OPENAI_BASE_URL` for non-streaming gateways, and a note to keep reverse-proxy read/idle timeouts above the longest completion time (no bytes flow while a single response generates).

Relates: lightdash/lightdash#23948
