### PR TITLE
docs: fix bold-around-code emphasis in LD_SETUP by-name matching

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -778,7 +778,7 @@ On server start, we will check the following variables, and update some configur
 
 Set `LD_SETUP_PROJECTS` to a JSON array to provision **multiple projects at once**. This is a drop-in replacement for the single-project `LD_SETUP_PROJECT_*` variables described in [Initialize instance](#initialize-instance) — when `LD_SETUP_PROJECTS` is set, the legacy `LD_SETUP_PROJECT_*` and `LD_SETUP_GITHUB_*` variables are ignored.
 
-On every boot, Lightdash matches each entry to an existing project **by `name`**: new names are created, existing names are updated in place.
+On every boot, Lightdash matches each entry to an existing project by its `name`: new names are created, existing names are updated in place.
 
 <Info>
   Currently we only support Databricks project types and GitHub dbt configuration for multi-project setup.
@@ -967,7 +967,7 @@ Set `LD_SETUP_USER_ATTRIBUTES` to a JSON array to declare [user attributes](/ref
   For more information on our plans, visit our [pricing page](https://www.lightdash.com/pricing).
 </Info>
 
-On every boot, Lightdash matches each entry to an existing user attribute **by `name`**: new names are created, existing names are updated in place. Attributes that are not present in the array are left untouched — this reconcile is non-destructive and never deletes attributes you created in the UI.
+On every boot, Lightdash matches each entry to an existing user attribute by its `name`: new names are created, existing names are updated in place. Attributes that are not present in the array are left untouched — this reconcile is non-destructive and never deletes attributes you created in the UI.
 
 ### Schema
 


### PR DESCRIPTION
## What

`**by `name`**` renders as a bold "by" followed by a separate code chip — markdown can't apply bold *across* a code span, so the emphasis lands on the wrong word.

Reworded to **by its `name`** in both places the phrase appears on the environment-variables page:
- `LD_SETUP_PROJECTS` section (pre-existing)
- `LD_SETUP_USER_ATTRIBUTES` section (added in #811; the bot copied the projects wording)

Cosmetic only — the described behaviour is unchanged.

Follow-up to #811.