### PR TITLE
fix: improve docs PR assignment coverage

### DIFF
--- a/.github/workflows/assign-docs-pr.yml
+++ b/.github/workflows/assign-docs-pr.yml
@@ -2,7 +2,7 @@ name: Assign Docs PR
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, ready_for_review, synchronize]
 
 permissions:
   issues: write
@@ -12,7 +12,6 @@ jobs:
   assign-docs-pr:
     name: Assign docs PR to source PR author
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'mintlify[bot]'
 
     steps:
       - name: Assign source PR author
@@ -21,6 +20,11 @@ jobs:
           script: |
             const docsPr = context.payload.pull_request;
             const body = docsPr.body || '';
+            const handleAliases = new Map([
+              ['tatiana', 'tatianainama'],
+              ['tatiana-inama', 'tatianainama'],
+            ]);
+            const normalizeHandle = (handle) => handleAliases.get(handle.toLowerCase()) || handle;
             const sourceMatch = body.match(/lightdash\/lightdash(?:#|\/pull\/)(\d+)/i);
             const contextualSourceMatch = body.match(/(?:upstream PR|source PR|triggered by|follows|follow-up to)[^#]{0,120}#(\d{5,})/is);
             let sourcePrNumber = sourceMatch ? Number(sourceMatch[1]) : undefined;
@@ -68,7 +72,7 @@ jobs:
                 core.info(`Could not load lightdash/lightdash#${sourcePrNumber} (${error.status || error.message}). Falling back to cc mention.`);
               }
 
-              const sourceAuthor = sourcePr?.user?.login;
+              const sourceAuthor = sourcePr?.user?.login ? normalizeHandle(sourcePr.user.login) : undefined;
               if (sourcePr && !sourceAuthor) {
                 core.info(`Source PR #${sourcePrNumber} has no author.`);
               } else if (sourceAuthor?.endsWith('[bot]')) {
@@ -83,7 +87,7 @@ jobs:
             if (!author) {
               const ccMatch = body.match(/(?:^|\n)\s*cc\s+@([A-Za-z0-9-]+)/i);
               if (ccMatch) {
-                const ccAuthor = ccMatch[1];
+                const ccAuthor = normalizeHandle(ccMatch[1]);
                 if (ccAuthor.endsWith('[bot]')) {
                   core.info(`cc mention is bot @${ccAuthor}. Skipping.`);
                 } else {
@@ -93,22 +97,31 @@ jobs:
               }
             }
 
+            if (!author && docsPr.user?.login && !docsPr.user.login.endsWith('[bot]')) {
+              author = normalizeHandle(docsPr.user.login);
+              reason = 'docs PR author';
+            }
+
             if (!author) {
               core.info('No lightdash/lightdash source PR author or cc mention found.');
               return;
             }
 
-            const { data: issue } = await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: docsPr.number,
-              assignees: [author],
-            });
+            try {
+              const { data: issue } = await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: docsPr.number,
+                assignees: [author],
+              });
 
-            const wasAssigned = issue.assignees?.some((assignee) => assignee.login === author);
-            if (wasAssigned) {
-              core.info(`Assigned docs PR #${docsPr.number} to ${author} via ${reason}.`);
-              return;
+              const wasAssigned = issue.assignees?.some((assignee) => assignee.login === author);
+              if (wasAssigned) {
+                core.info(`Assigned docs PR #${docsPr.number} to ${author} via ${reason}.`);
+                return;
+              }
+            } catch (error) {
+              core.info(`Could not assign docs PR #${docsPr.number} to ${author} (${error.status || error.message}). Falling back to cc comment.`);
             }
 
             const fallbackBody = `cc @${author}`;
@@ -125,11 +138,15 @@ jobs:
               return;
             }
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: docsPr.number,
-              body: fallbackBody,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: docsPr.number,
+                body: fallbackBody,
+              });
 
-            core.info(`Assignment did not land for ${author}. Posted fallback cc comment.`);
+              core.info(`Assignment did not land for ${author}. Posted fallback cc comment.`);
+            } catch (error) {
+              core.info(`Assignment and fallback comment both failed for ${author} (${error.status || error.message}).`);
+            }

--- a/scripts/backfill-docs-pr-assignees.sh
+++ b/scripts/backfill-docs-pr-assignees.sh
@@ -22,6 +22,22 @@ resolve_cc_from_text() {
   perl -0777 -ne 'if (/(?:^|\n)\s*cc\s+@([A-Za-z0-9-]+)/i) { print $1; exit }'
 }
 
+normalize_handle() {
+  local handle="$1"
+  local lower_handle
+
+  lower_handle="$(printf "%s" "$handle" | tr '[:upper:]' '[:lower:]')"
+
+  case "$lower_handle" in
+    tatiana|tatiana-inama)
+      printf "tatianainama"
+      ;;
+    *)
+      printf "%s" "$handle"
+      ;;
+  esac
+}
+
 source_pr_author() {
   local source_number="$1"
 
@@ -40,10 +56,12 @@ assign_or_comment() {
   local author="$2"
 
   local response
-  response="$(gh api -X POST "repos/$DOCS_REPO/issues/$pr_number/assignees" -f "assignees[]=$author")"
-
-  if printf "%s" "$response" | jq -e --arg author "$author" '.assignees // [] | any(.login == $author)' >/dev/null; then
-    return 0
+  if response="$(gh api -X POST "repos/$DOCS_REPO/issues/$pr_number/assignees" -f "assignees[]=$author" 2>/dev/null)"; then
+    if printf "%s" "$response" | jq -e --arg author "$author" '.assignees // [] | any(.login == $author)' >/dev/null; then
+      return 0
+    fi
+  else
+    echo "WARN PR #$pr_number: assignment to @$author failed, trying fallback cc comment" >&2
   fi
 
   local fallback_body="cc @$author"
@@ -55,7 +73,10 @@ assign_or_comment() {
     return 1
   fi
 
-  gh pr comment "$pr_number" -R "$DOCS_REPO" --body "$fallback_body" >/dev/null
+  if ! gh pr comment "$pr_number" -R "$DOCS_REPO" --body "$fallback_body" >/dev/null; then
+    echo "WARN PR #$pr_number: fallback cc comment for @$author failed" >&2
+  fi
+
   return 1
 }
 
@@ -63,7 +84,7 @@ require_command gh
 require_command jq
 require_command perl
 
-prs_json="$(gh pr list -R "$DOCS_REPO" --state open --limit 200 --json number,title,body,assignees,url)"
+prs_json="$(gh pr list -R "$DOCS_REPO" --state open --limit 200 --json number,title,body,assignees,url,author)"
 count="$(printf "%s" "$prs_json" | jq 'length')"
 
 echo "Found $count open PRs in $DOCS_REPO"
@@ -73,6 +94,8 @@ printf "%s" "$prs_json" | jq -c '.[] | select((.assignees | length) == 0)' | whi
   number="$(printf "%s" "$pr" | jq -r '.number')"
   title="$(printf "%s" "$pr" | jq -r '.title')"
   body="$(printf "%s" "$pr" | jq -r '.body // ""')"
+  pr_author="$(printf "%s" "$pr" | jq -r '.author.login // ""')"
+  pr_author_is_bot="$(printf "%s" "$pr" | jq -r '.author.is_bot // false')"
   source_number="$(printf "%s" "$body" | resolve_source_from_text)"
   reason=""
 
@@ -93,6 +116,8 @@ printf "%s" "$prs_json" | jq -c '.[] | select((.assignees | length) == 0)' | whi
       continue
     fi
 
+    author="$(normalize_handle "$author")"
+
     if [[ "$author" == *"[bot]" ]]; then
       echo "SKIP PR #$number: $SOURCE_REPO#$source_number author is bot $author: $title"
       continue
@@ -111,6 +136,7 @@ printf "%s" "$prs_json" | jq -c '.[] | select((.assignees | length) == 0)' | whi
 
   cc_author="$(printf "%s" "$body" | resolve_cc_from_text)"
   if [[ -n "$cc_author" ]]; then
+    cc_author="$(normalize_handle "$cc_author")"
     if [[ "$cc_author" == *"[bot]" ]]; then
       echo "SKIP PR #$number: cc mention is bot @$cc_author: $title"
       continue
@@ -122,6 +148,20 @@ printf "%s" "$prs_json" | jq -c '.[] | select((.assignees | length) == 0)' | whi
       echo "ASSIGNED PR #$number to @$cc_author from cc mention: $title"
     else
       echo "FALLBACK PR #$number: assignment to @$cc_author did not stick, fallback cc exists or was posted: $title"
+    fi
+
+    continue
+  fi
+
+  if [[ -n "$pr_author" && "$pr_author_is_bot" != "true" ]]; then
+    pr_author="$(normalize_handle "$pr_author")"
+
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "DRY RUN PR #$number: would assign @$pr_author from docs PR author: $title"
+    elif assign_or_comment "$number" "$pr_author"; then
+      echo "ASSIGNED PR #$number to @$pr_author from docs PR author: $title"
+    else
+      echo "FALLBACK PR #$number: assignment to @$pr_author did not stick, fallback cc exists or was posted: $title"
     fi
 
     continue


### PR DESCRIPTION
## Summary

Fixes the docs PR assignment workflow so it catches more of the PRs it is meant to assign and does not fail before the fallback path can run.

## What changed

- Run the assignment workflow for human-authored docs PRs, `ready_for_review`, and `synchronize` events.
- Fall back to assigning the docs PR author when no upstream source PR or `cc @user` mention is found.
- Normalize known Tatiana handle variants to `tatianainama`.
- Catch assignment API failures and attempt the existing fallback `cc @user` comment instead of failing the job.
- Keep `scripts/backfill-docs-pr-assignees.sh` aligned with the workflow behavior.

## Root cause

The workflow was scoped to `mintlify[bot]` PRs only, so human-authored docs PRs like Tatiana PRs were skipped. It also assumed `addAssignees` would return a response instead of throwing, so the fallback comment path was unreachable for API failures.

## Validation

- `bash -n scripts/backfill-docs-pr-assignees.sh`
- Inline `actions/github-script` syntax check with an async JS wrapper
- `git diff --check`
- `DRY_RUN=1 scripts/backfill-docs-pr-assignees.sh`
- Ran `DRY_RUN=0 scripts/backfill-docs-pr-assignees.sh` to backfill current open unassigned PRs before publishing