### PR TITLE
docs: restructure LLM gateway section and fix OPENAI_ZERO_DATA_RETENTION description

### DIFF
--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -409,7 +409,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 
 If your proxy or gateway doesn't support streaming (SSE) completions, also set `OPENAI_SUPPORTS_STREAMING=false`. Lightdash will then make a single non-streaming request per model call — the AI agent keeps working unchanged, including the chat UI. Note that while a response is generating no bytes flow through the connection, so make sure any reverse proxy in the path has a read/idle timeout above your longest completion time.
 
-If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true`. Without it, multi-step AI agent conversations with reasoning models will fail because the model tries to reference server-stored reasoning IDs that ZDR prevents from being persisted.
+If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true`.
 </Tip>
 
 #### Anthropic Configuration

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -393,8 +393,7 @@ To enable AI Analyst, set `AI_COPILOT_ENABLED=true` and provide an API key for `
 | `OPENAI_CUSTOM_HEADERS`  | JSON object of extra HTTP headers to send with every OpenAI request                          |
 | `OPENAI_SUPPORTS_STREAMING` | Set to `false` if the endpoint behind `OPENAI_BASE_URL` (e.g. an LLM gateway) doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
-<Tip>
-**Using an OpenAI-compatible proxy (e.g. LiteLLM)**
+#### Using an LLM gateway or proxy
 
 If your organization uses an OpenAI-compatible proxy like [LiteLLM](https://www.litellm.ai/), you can connect it to Lightdash by setting `AI_DEFAULT_PROVIDER=openai` and pointing `OPENAI_BASE_URL` to your proxy URL. For example:
 
@@ -410,7 +409,6 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 If your proxy or gateway doesn't support streaming (SSE) completions, also set `OPENAI_SUPPORTS_STREAMING=false`. Lightdash will then make a single non-streaming request per model call — the AI agent keeps working unchanged, including the chat UI. Note that while a response is generating no bytes flow through the connection, so make sure any reverse proxy in the path has a read/idle timeout above your longest completion time.
 
 If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true` — otherwise multi-step AI agent conversations with reasoning models will fail.
-</Tip>
 
 #### Anthropic Configuration
 

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -389,7 +389,7 @@ To enable AI Analyst, set `AI_COPILOT_ENABLED=true` and provide an API key for `
 | `OPENAI_EMBEDDING_MODEL`  | OpenAI embedding model for verified answers (default=text-embedding-3-small)                |
 | `OPENAI_BASE_URL`         | Optional base URL for OpenAI compatible API                                                 |
 | `OPENAI_AVAILABLE_MODELS` | Comma-separated list of models available in the model picker (default=All supported models) |
-| `OPENAI_ZERO_DATA_RETENTION` | Sets the OpenAI `OpenAI-Beta: assistants-zdr` header so prompts and completions are not retained by OpenAI. (default=false) |
+| `OPENAI_ZERO_DATA_RETENTION` | Set to `true` if your OpenAI account or LLM gateway enforces Zero Data Retention (ZDR). Lightdash will include reasoning content directly in each request instead of referencing server-stored IDs — required for multi-step AI agent conversations to work under ZDR. (default=false) |
 | `OPENAI_CUSTOM_HEADERS`  | JSON object of extra HTTP headers to send with every OpenAI request                          |
 | `OPENAI_SUPPORTS_STREAMING` | Set to `false` if the endpoint behind `OPENAI_BASE_URL` (e.g. an LLM gateway) doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
@@ -408,6 +408,8 @@ Make sure your proxy has the model names correctly mapped. For example, if you s
 If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_MODELS` with a comma-separated list of model names.
 
 If your proxy or gateway doesn't support streaming (SSE) completions, also set `OPENAI_SUPPORTS_STREAMING=false`. Lightdash will then make a single non-streaming request per model call — the AI agent keeps working unchanged, including the chat UI. Note that while a response is generating no bytes flow through the connection, so make sure any reverse proxy in the path has a read/idle timeout above your longest completion time.
+
+If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true`. Without it, multi-step AI agent conversations with reasoning models will fail because the model tries to reference server-stored reasoning IDs that ZDR prevents from being persisted.
 </Tip>
 
 #### Anthropic Configuration

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -389,7 +389,7 @@ To enable AI Analyst, set `AI_COPILOT_ENABLED=true` and provide an API key for `
 | `OPENAI_EMBEDDING_MODEL`  | OpenAI embedding model for verified answers (default=text-embedding-3-small)                |
 | `OPENAI_BASE_URL`         | Optional base URL for OpenAI compatible API                                                 |
 | `OPENAI_AVAILABLE_MODELS` | Comma-separated list of models available in the model picker (default=All supported models) |
-| `OPENAI_ZERO_DATA_RETENTION` | Set to `true` if your OpenAI account or LLM gateway enforces Zero Data Retention (ZDR). Lightdash will include reasoning content directly in each request instead of referencing server-stored IDs — required for multi-step AI agent conversations to work under ZDR. (default=false) |
+| `OPENAI_ZERO_DATA_RETENTION` | Set to `true` if your OpenAI account or LLM gateway enforces Zero Data Retention (ZDR). (default=false) |
 | `OPENAI_CUSTOM_HEADERS`  | JSON object of extra HTTP headers to send with every OpenAI request                          |
 | `OPENAI_SUPPORTS_STREAMING` | Set to `false` if the endpoint behind `OPENAI_BASE_URL` (e.g. an LLM gateway) doesn't support streaming (SSE) completions — Lightdash will make non-streaming requests instead (default=true) |
 
@@ -409,7 +409,7 @@ If you want to expose multiple models through the proxy, use `OPENAI_AVAILABLE_M
 
 If your proxy or gateway doesn't support streaming (SSE) completions, also set `OPENAI_SUPPORTS_STREAMING=false`. Lightdash will then make a single non-streaming request per model call — the AI agent keeps working unchanged, including the chat UI. Note that while a response is generating no bytes flow through the connection, so make sure any reverse proxy in the path has a read/idle timeout above your longest completion time.
 
-If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true`.
+If your gateway enforces Zero Data Retention (ZDR), also set `OPENAI_ZERO_DATA_RETENTION=true` — otherwise multi-step AI agent conversations with reasoning models will fail.
 </Tip>
 
 #### Anthropic Configuration


### PR DESCRIPTION
## Summary

- Converts the OpenAI proxy/gateway Tip block into a proper `####` subsection ("Using an LLM gateway or proxy") — it had grown too large for a tip
- Fixes the `OPENAI_ZERO_DATA_RETENTION` variable description, which incorrectly said it sets an HTTP header — updated to be accurate and concise
- Adds a brief note about `OPENAI_ZERO_DATA_RETENTION=true` being required for ZDR-enforcing gateways, with a one-line explanation of why