### PR TITLE
docs(timezones-draft): add DST merge-bucketing charts

### DIFF
--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -285,26 +285,53 @@ the drill returns all 23 events — there is simply no 02:10 to return.
 
 ### Hourly charts
 
-At hour grain the transition is visible in the bars themselves. On **fall-back** the two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, but the same wall-clock label) **merge into a single `01:00` bucket** with double the count. On **spring-forward** the `02:00` bucket is simply absent. In both cases the count still reconciles with the drill-down: the `01:00` bar that reads `2` drills into exactly 2 rows.
+At hour grain the fall-back fold is visible in the bars, and there are **two design options** for how to handle it. Spring-forward looks the same under both — there's no repeated hour to split, only the missing `02:00` (shown at the end).
 
-#### Clocks go back — fall-back
+#### Fall-back, Option A — merge (one `01:00` bar)
+
+The two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, same wall-clock label) collapse into a single `01:00` bucket with double the count.
 
 ```text
-count/hour · America/New_York
+count/hour · America/New_York · MERGE
 
   2 ┤             ┌────┐
-    │             │████│ ← 01:00 EDT + 01:00 EST land in one bucket
+    │             │████│ ← 01:00 EDT + 01:00 EST in one bucket
   1 ┤ ┌──┐┌──┐┌──┐│████│┌──┐┌──┐┌──┐
     │ │██││██││██││████││██││██││██│
     └─┴──┴┴──┴┴──┴┴────┴┴──┴┴──┴┴──┴─
       22  23  00  01   02  03  04   (local hour)
       └─ EDT (−4) ┘    └─ EST (−5) ┘
 
-Drill the 01:00 bar → 2 rows (the 05:10Z and 06:10Z events). The bar's
-count and its drill-down agree.
+Drill the 01:00 bar → 2 rows (05:10Z and 06:10Z). Count and drill-down agree.
+One bar per wall-clock hour; matches other BI tools; the extra hour reads as a
+spike — which can look like a real event on a constant-rate source.
 ```
 
-#### Clocks go forward — spring-forward
+#### Fall-back, Option B — split (two `01:00` bars)
+
+Each real hour keeps its own bucket, so a constant-rate source stays flat across the fold.
+
+```text
+count/hour · America/New_York · SPLIT
+
+  1 ┤ ┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐
+    │ │██││██││██││██││██││██││██││██│
+    └─┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴─
+      22  23  00  01  01  02  03  04   (local hour)
+                  ▲   ▲
+                 −4   −5   ← same wall-clock 01:00, one real hour apart
+```
+
+This reconciles with drill-down **only if the bucket's identity is the UTC instant**, not the rendered wall-clock label. The drill filter is then an instant range, so each bar maps to exactly its own row:
+
+- click the first `01:00` bar → `instant in [05:00Z, 06:00Z)` → 1 row
+- click the second `01:00` bar → `instant in [06:00Z, 07:00Z)` → 1 row
+
+Telling the two bars apart on the axis (e.g. `1am −4` / `1am −5`) is a display concern layered on top — the backend keys on the instant, the frontend chooses the label.
+
+#### Spring-forward (identical under both options)
+
+No repeated hour, so nothing to merge or split — the `02:00` bucket is simply absent.
 
 ```text
 count/hour · America/New_York
@@ -318,7 +345,7 @@ count/hour · America/New_York
 ```
 
 <Note>
-**Why merge and not two `01:00` bars?** Splitting the fold into two buckets is "technically faithful" but surprising, and it can't be done consistently across every warehouse Lightdash supports. Merging is what most BI tools do, what reading "01:00" on an axis leads you to expect, and it keeps the bar's count equal to its drill-down. If you genuinely need to separate the two physical hours, group by the raw UTC instant (or a `convert_timezone: false` dimension) instead. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+**Merge vs split — the trade-off.** Both are correct, and both reconcile with drill-down *provided the backend keys buckets on the UTC instant rather than the rendered wall-clock label*. Today it keys on the label, which is the only reason merge currently stays self-consistent and split does not — that's the thing to fix first. Once buckets are instant-keyed, the choice is a presentation one: **merge** matches other BI tools and shows one bar per wall-clock hour, at the cost of a once-a-year spike on the fall-back hour; **split** keeps a constant-rate source flat and is more faithful, at the cost of two same-time bars that need an offset in the label. A single instant-keyed backend can serve either — or offer both. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
 </Note>
 
 ## Sharing charts: pinning vs viewer timezone

--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -213,48 +213,112 @@ A chart grouped by **hour, minute, or smaller** buckets data by instants. The bo
 
 ## Daylight-saving transitions
 
-Twice a year the clock jumps. In a DST zone like `America/New_York`, the **fall-back** day is 25 hours long (clocks go back, so 1 AM happens twice) and the **spring-forward** day is 23 hours long (clocks go forward, so 2 AM never happens). Lightdash buckets data in the project timezone, so these show up in your charts. Here's exactly how, using a source that emits one event every real hour. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+Twice a year the clock jumps. In a DST zone like `America/New_York`, the **fall-back** day is 25 hours long (clocks go back, so 1 AM happens twice) and the **spring-forward** day is 23 hours long (clocks go forward, so 2 AM never happens). Lightdash buckets data in the project timezone, so these show up in your charts.
+
+The rule that keeps everything consistent: **a bar holds exactly the events you get when you drill into it** — a single, contiguous slice of real time. Every example below uses a source that emits one event per real hour, at 10 minutes past, in `America/New_York`. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
 
 ### Daily charts
 
-A daily chart simply counts every event that fell on each local calendar day. The fall-back day has 25 hours of events; the spring-forward day has 23. The bar is genuinely taller (or shorter) — this is correct, not a bug, and it looks the same on every warehouse.
+A daily bar counts every event in that local calendar day. The fall-back day genuinely contains 25 hours of events and the spring-forward day 23 — so the bar is taller or shorter. This is correct, not a bug, and it looks the same on every warehouse. Drilling a day always returns exactly its events, because a calendar day is one clean range of real time regardless of how many hours it held.
+
+#### Clocks go back — fall-back (Nov 3, 2024): a 25-hour day
 
 ```text
-events/day                              America/New_York · 1 event per real hour
+events/day · America/New_York · 1 event per real hour
 
-DST back  (fall-back, Nov 3)            DST forward  (spring-forward, Mar 10)
+  25 ┤             ┌────┐
+  24 ┤ ┌────┐┌────┐│████│┌────┐┌────┐
+     │ │████││████││████││████││████│
+     └─┴────┴┴────┴┴────┴┴────┴┴────┴─
+       Nov1  Nov2  Nov3  Nov4  Nov5
+        24    24   [25]   24    24
+                    ▲ 25-hour day (clocks go back)
+```
 
-  25 ┤             ┌────┐                 24 ┤ ┌────┐┌────┐        ┌────┐┌────┐
-  24 ┤ ┌────┐┌────┐│████│┌────┐┌────┐     23 ┤ │████││████│ ┌────┐ │████││████│
-     │ │████││████││████││████││████│        │ │████││████│ │████│ │████││████│
-     │ │████││████││████││████││████│        │ │████││████│ │████│ │████││████│
-     └─┴────┴┴────┴┴────┴┴────┴┴────┴─       └─┴────┴┴────┴─┴────┴─┴────┴┴────┴─
-       Nov1  Nov2  Nov3  Nov4  Nov5           Mar8  Mar9  Mar10  Mar11 Mar12
-        24    24    25    24    24              24    24    23     24    24
-                  ▲ 25-hour day                            ▲ 23-hour day
+```text
+Click the Nov 3 bar → "show underlying data" → 25 rows
+
+  #    local (America/New_York)      UTC instant
+ ──────────────────────────────────────────────────────
+  1    2024-11-03 00:10  EDT (−4)    2024-11-03 04:10Z
+  2    2024-11-03 01:10  EDT (−4)    2024-11-03 05:10Z   ┐ two events at 01:10,
+  3    2024-11-03 01:10  EST (−5)    2024-11-03 06:10Z   ┘ one real hour apart
+  4    2024-11-03 02:10  EST (−5)    2024-11-03 07:10Z
+  5    2024-11-03 03:10  EST (−5)    2024-11-03 08:10Z
+  ⋮                                  ⋮
+ 25    2024-11-03 23:10  EST (−5)    2024-11-04 04:10Z
+
+The day is one contiguous range (04:10Z → next-day 04:10Z = 25 h), so the
+drill returns all 25 events — including both 01:10s.
+```
+
+#### Clocks go forward — spring-forward (Mar 10, 2024): a 23-hour day
+
+```text
+events/day · America/New_York · 1 event per real hour
+
+  24 ┤ ┌────┐┌────┐      ┌────┐┌────┐
+  23 ┤ │████││████│┌────┐│████││████│
+     │ │████││████││████││████││████│
+     └─┴────┴┴────┴┴────┴┴────┴┴────┴─
+       Mar8  Mar9  Mar10 Mar11 Mar12
+        24    24   [23]   24    24
+                    ▲ 23-hour day (clocks go forward)
+```
+
+```text
+Click the Mar 10 bar → "show underlying data" → 23 rows
+
+  #    local (America/New_York)      UTC instant
+ ──────────────────────────────────────────────────────
+  1    2024-03-10 00:10  EST (−5)    2024-03-10 05:10Z
+  2    2024-03-10 01:10  EST (−5)    2024-03-10 06:10Z
+  –    (no 02:10 — the 02:00–03:00 hour never happened)
+  3    2024-03-10 03:10  EDT (−4)    2024-03-10 07:10Z
+  4    2024-03-10 04:10  EDT (−4)    2024-03-10 08:10Z
+  ⋮                                  ⋮
+ 23    2024-03-10 23:10  EDT (−4)    2024-03-11 03:10Z
+
+The day is again one contiguous range (05:10Z → next-day 03:10Z = 23 h), so
+the drill returns all 23 events — there is simply no 02:10 to return.
 ```
 
 ### Hourly charts
 
-This is where the fold is visible. On **fall-back**, the two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, but the same wall-clock label) are **merged into a single `01:00` bucket** with double the count. On **spring-forward**, the `02:00` bucket is simply absent, because that hour never happened.
+At hour grain the transition is visible in the bars themselves. On **fall-back** the two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, but the same wall-clock label) **merge into a single `01:00` bucket** with double the count. On **spring-forward** the `02:00` bucket is simply absent. In both cases the count still reconciles with the drill-down: the `01:00` bar that reads `2` drills into exactly 2 rows.
+
+#### Clocks go back — fall-back
 
 ```text
-count                                   bucket = hour in America/New_York
+count/hour · America/New_York
 
-DST back  (fall-back)                          DST forward  (spring-forward)
+  2 ┤             ┌────┐
+    │             │████│ ← 01:00 EDT + 01:00 EST land in one bucket
+  1 ┤ ┌──┐┌──┐┌──┐│████│┌──┐┌──┐┌──┐
+    │ │██││██││██││████││██││██││██│
+    └─┴──┴┴──┴┴──┴┴────┴┴──┴┴──┴┴──┴─
+      22  23  00  01   02  03  04   (local hour)
+      └─ EDT (−4) ┘    └─ EST (−5) ┘
 
-  2 ┤             ┌────┐                          1 ┤ ┌──┐┌──┐┌──┐      ┌──┐┌──┐┌──┐
-    │             │████│ ← both 1 AMs merged        │ │██││██││██│ ┄┄┄┄ │██││██││██│
-  1 ┤ ┌──┐┌──┐┌──┐│████│┌──┐┌──┐┌──┐               └─┴──┴┴──┴┴──┴─┴────┴┴──┴┴──┴┴──┴─
-    │ │██││██││██││████││██││██││██│                  23  00  01   02   03  04  05
-    └─┴──┴┴──┴┴──┴┴────┴┴──┴┴──┴┴──┴─                 └ EST(−5)┘    ▲   └─ EDT(−4) ─┘
-      22  23  00  01   02  03  04                                no 02:00 bucket
-      └─ EDT(−4) ┘ ▲   └─ EST(−5) ┘                              (hour skipped)
-                 fold: count = 2
+Drill the 01:00 bar → 2 rows (the 05:10Z and 06:10Z events). The bar's
+count and its drill-down agree.
+```
+
+#### Clocks go forward — spring-forward
+
+```text
+count/hour · America/New_York
+
+  1 ┤ ┌──┐┌──┐┌──┐      ┌──┐┌──┐┌──┐
+    │ │██││██││██│ ┄┄┄┄ │██││██││██│
+    └─┴──┴┴──┴┴──┴─┴────┴┴──┴┴──┴┴──┴─
+      23  00  01   02   03  04  05   (local hour)
+      └ EST (−5) ┘  ▲   └─ EDT (−4) ┘
+            no 02:00 bucket (hour skipped)
 ```
 
 <Note>
-**Why merge and not two `01:00` bars?** Splitting the fold into two buckets is "technically faithful" but surprising, and it can't be done consistently across every warehouse Lightdash supports. Merging is what most BI tools do and what reading "01:00" on an axis leads you to expect. If you genuinely need to separate the two physical hours, group by the raw UTC instant (or a `convert_timezone: false` dimension) instead. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+**Why merge and not two `01:00` bars?** Splitting the fold into two buckets is "technically faithful" but surprising, and it can't be done consistently across every warehouse Lightdash supports. Merging is what most BI tools do, what reading "01:00" on an axis leads you to expect, and it keeps the bar's count equal to its drill-down. If you genuinely need to separate the two physical hours, group by the raw UTC instant (or a `convert_timezone: false` dimension) instead. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
 </Note>
 
 ## Sharing charts: pinning vs viewer timezone

--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -285,9 +285,9 @@ the drill returns all 23 events — there is simply no 02:10 to return.
 
 ### Hourly charts
 
-At hour grain the fall-back fold is visible in the bars, and there are **two design options** for how to handle it. Spring-forward looks the same under both — there's no repeated hour to split, only the missing `02:00` (shown at the end).
+At hour grain the fall-back fold is visible in the bars — and on every warehouse it **merges** into one bar. Spring-forward has no repeated hour, only the missing `02:00` (shown below).
 
-#### Fall-back, Option A — merge (one `01:00` bar)
+#### Fall-back: the two 1 AM hours merge into one bar
 
 The two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, same wall-clock label) collapse into a single `01:00` bucket with double the count.
 
@@ -307,31 +307,9 @@ One bar per wall-clock hour; matches other BI tools; the extra hour reads as a
 spike — which can look like a real event on a constant-rate source.
 ```
 
-#### Fall-back, Option B — split (two `01:00` bars)
+#### Spring-forward
 
-Each real hour keeps its own bucket, so a constant-rate source stays flat across the fold.
-
-```text
-count/hour · America/New_York · SPLIT
-
-  1 ┤ ┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐
-    │ │██││██││██││██││██││██││██││██│
-    └─┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴┴──┴─
-      22  23  00  01  01  02  03  04   (local hour)
-                  ▲   ▲
-                 −4   −5   ← same wall-clock 01:00, one real hour apart
-```
-
-This reconciles with drill-down **only if the bucket's identity is the UTC instant**, not the rendered wall-clock label. The drill filter is then an instant range, so each bar maps to exactly its own row:
-
-- click the first `01:00` bar → `instant in [05:00Z, 06:00Z)` → 1 row
-- click the second `01:00` bar → `instant in [06:00Z, 07:00Z)` → 1 row
-
-Telling the two bars apart on the axis (e.g. `1am −4` / `1am −5`) is a display concern layered on top — the backend keys on the instant, the frontend chooses the label.
-
-#### Spring-forward (identical under both options)
-
-No repeated hour, so nothing to merge or split — the `02:00` bucket is simply absent.
+No repeated hour, so there's nothing to fold — the `02:00` bucket is simply absent.
 
 ```text
 count/hour · America/New_York
@@ -345,7 +323,7 @@ count/hour · America/New_York
 ```
 
 <Note>
-**Merge vs split — the trade-off.** Both are correct, and both reconcile with drill-down *provided the backend keys buckets on the UTC instant rather than the rendered wall-clock label*. Today it keys on the label, which is the only reason merge currently stays self-consistent and split does not — that's the thing to fix first. Once buckets are instant-keyed, the choice is a presentation one: **merge** matches other BI tools and shows one bar per wall-clock hour, at the cost of a once-a-year spike on the fall-back hour; **split** keeps a constant-rate source flat and is more faithful, at the cost of two same-time bars that need an offset in the label. A single instant-keyed backend can serve either — or offer both. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+**Why merge?** Under Lightdash's wall-clock grouping, both folds are "1 AM" locally, so they belong in one bucket — and merge matches what other BI tools do. The cost is a once-a-year `count = 2` spike on the fall-back hour. Splitting the fold into two same-time bars would keep a constant-rate source flat, but it needs an offset in the axis label to tell the two `01:00` bars apart; it isn't offered today. *— [GLITCH-509](https://linear.app/lightdash/issue/GLITCH-509)*
 </Note>
 
 ## Sharing charts: pinning vs viewer timezone

--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -211,6 +211,52 @@ A chart grouped by **hour, minute, or smaller** buckets data by instants. The bo
 
 **Implication:** sub-day grouping is naturally consistent across viewers. The only exception is half-hour and 45-minute offset zones (India, Nepal, parts of Australia), where bucket boundaries don't align with whole-hour zones. Hour-grain charts spanning a daylight-saving transition may also render with a one-hour visual jump at the boundary. *— [GLITCH-453](https://linear.app/lightdash/issue/GLITCH-453), [GLITCH-449](https://linear.app/lightdash/issue/GLITCH-449)*
 
+## Daylight-saving transitions
+
+Twice a year the clock jumps. In a DST zone like `America/New_York`, the **fall-back** day is 25 hours long (clocks go back, so 1 AM happens twice) and the **spring-forward** day is 23 hours long (clocks go forward, so 2 AM never happens). Lightdash buckets data in the project timezone, so these show up in your charts. Here's exactly how, using a source that emits one event every real hour. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+
+### Daily charts
+
+A daily chart simply counts every event that fell on each local calendar day. The fall-back day has 25 hours of events; the spring-forward day has 23. The bar is genuinely taller (or shorter) — this is correct, not a bug, and it looks the same on every warehouse.
+
+```text
+events/day                              America/New_York · 1 event per real hour
+
+DST back  (fall-back, Nov 3)            DST forward  (spring-forward, Mar 10)
+
+  25 ┤             ┌────┐                 24 ┤ ┌────┐┌────┐        ┌────┐┌────┐
+  24 ┤ ┌────┐┌────┐│████│┌────┐┌────┐     23 ┤ │████││████│ ┌────┐ │████││████│
+     │ │████││████││████││████││████│        │ │████││████│ │████│ │████││████│
+     │ │████││████││████││████││████│        │ │████││████│ │████│ │████││████│
+     └─┴────┴┴────┴┴────┴┴────┴┴────┴─       └─┴────┴┴────┴─┴────┴─┴────┴┴────┴─
+       Nov1  Nov2  Nov3  Nov4  Nov5           Mar8  Mar9  Mar10  Mar11 Mar12
+        24    24    25    24    24              24    24    23     24    24
+                  ▲ 25-hour day                            ▲ 23-hour day
+```
+
+### Hourly charts
+
+This is where the fold is visible. On **fall-back**, the two 1 AM hours (`01:00` EDT and `01:00` EST — one real hour apart, but the same wall-clock label) are **merged into a single `01:00` bucket** with double the count. On **spring-forward**, the `02:00` bucket is simply absent, because that hour never happened.
+
+```text
+count                                   bucket = hour in America/New_York
+
+DST back  (fall-back)                          DST forward  (spring-forward)
+
+  2 ┤             ┌────┐                          1 ┤ ┌──┐┌──┐┌──┐      ┌──┐┌──┐┌──┐
+    │             │████│ ← both 1 AMs merged        │ │██││██││██│ ┄┄┄┄ │██││██││██│
+  1 ┤ ┌──┐┌──┐┌──┐│████│┌──┐┌──┐┌──┐               └─┴──┴┴──┴┴──┴─┴────┴┴──┴┴──┴┴──┴─
+    │ │██││██││██││████││██││██││██│                  23  00  01   02   03  04  05
+    └─┴──┴┴──┴┴──┴┴────┴┴──┴┴──┴┴──┴─                 └ EST(−5)┘    ▲   └─ EDT(−4) ─┘
+      22  23  00  01   02  03  04                                no 02:00 bucket
+      └─ EDT(−4) ┘ ▲   └─ EST(−5) ┘                              (hour skipped)
+                 fold: count = 2
+```
+
+<Note>
+**Why merge and not two `01:00` bars?** Splitting the fold into two buckets is "technically faithful" but surprising, and it can't be done consistently across every warehouse Lightdash supports. Merging is what most BI tools do and what reading "01:00" on an axis leads you to expect. If you genuinely need to separate the two physical hours, group by the raw UTC instant (or a `convert_timezone: false` dimension) instead. *— [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504)*
+</Note>
+
 ## Sharing charts: pinning vs viewer timezone
 
 When you save a chart, Lightdash asks how you want viewers to see it:


### PR DESCRIPTION
Adds a **Daylight-saving transitions** section to the hidden `timezones-draft.mdx` reference page, with ASCII charts showing how DST shows up in charts. The hourly section is locked to the **merge** behavior we shipped in GLITCH-509 (one `01:00` bar at the fall-back, on every warehouse).

### What's added
- **Daily charts** — fall-back day is a 25-tall bar, spring-forward day a 23-tall bar. Identical on every warehouse, and a day always drills to exactly its events.
- **Hourly charts** — at the fall-back the two 1 AM hours merge into one `01:00` bucket (`count = 2`) and the bar drills to both events; spring-forward drops the `02:00` bucket entirely.
- A `<Note>` explaining why we merge, and noting that splitting the fold into two same-time bars isn't offered today.

Source example: one event per real hour, `America/New_York`.

### Scope
- Touches **only** `timezones-draft.mdx`.
- Does **not** touch `guides/developer/timezones.mdx`.
- The draft page is `hidden: true`, so nothing surfaces publicly.

Reflects the decision in [GLITCH-504](https://linear.app/lightdash/issue/GLITCH-504) (merge over split), now implemented and shipped behind \`EnableTimezoneSupport\` in [GLITCH-509](https://linear.app/lightdash/issue/GLITCH-509).