### PR TITLE
docs(ai-agents): document admin-only agent access

### DIFF
--- a/guides/ai-agents/getting-started.mdx
+++ b/guides/ai-agents/getting-started.mdx
@@ -106,7 +106,9 @@ Upload reference material — glossaries, metric definitions, business context, 
 ### Data Access
 By default, agents have data access enabled so they can analyze actual query results and provide insights based on the data. You can turn it off per agent if you want metadata-only behavior. Learn more in [data access control](/guides/ai-agents/data-access).
 ### User and Group Access (optional)
-Control which users and groups can access your agent through the agent settings. For detailed guidance on how to configure data access control, see [here](/guides/ai-agents/data-access#user-attributes-and-permissions)
+By default, your agent is available to everyone in the project. While you're still setting it up, you can keep it to **admins and developers only**, then open it up — to everyone, or to **specific users and groups** — once it's ready. You'll find these options under the agent's access settings.
+
+This controls who can use the agent, which is separate from [data access control](/guides/ai-agents/data-access) (what data the agent can query).
 ### Tags (optional)
 Use tags in the Lightdash metadata to control which metrics and dimensions the agent can access. Tags help you restrict your agent to a specific slice of your semantic layer.
 


### PR DESCRIPTION
Updates the AI agents getting-started guide to cover the new agent access options (everyone / admins & developers only / specific users & groups).

Accompanies lightdash/lightdash#24369