### PR TITLE
docs(embedding): CSS class overrides for embedded dashboards

### DIFF
--- a/guides/embedding/dashboards.mdx
+++ b/guides/embedding/dashboards.mdx
@@ -502,6 +502,8 @@ Apply custom styling to match your application's design.
 />
 ```
 
+For overrides the `styles` prop doesn't cover, embedded dashboards expose stable CSS classnames (e.g. `ld-dashboard-header`) you can target from your own stylesheet. See [CSS class overrides](/references/react-sdk#css-class-overrides).
+
 ### Localization (SDK only)
 
 Translate embedded dashboards using the `contentOverrides` prop. See [React SDK localization](/references/react-sdk#localization) for details.

--- a/references/react-sdk.mdx
+++ b/references/react-sdk.mdx
@@ -668,8 +668,10 @@ Beyond the `styles` prop, you can target embedded dashboard elements directly fr
 |------------------------------------|----------------------------------|
 | `ld-dashboard-header`              | The dashboard header bar         |
 | `ld-dashboard-filters`             | The filter bar row               |
+| `ld-dashboard-filter`              | An individual filter pill        |
 | `ld-dashboard-date-zoom`           | The date-zoom button             |
 | `ld-dashboard-parameters`          | The parameters row               |
+| `ld-dashboard-parameter`           | An individual parameter pill     |
 | `ld-dashboard-filter-dropdown`     | An open filter's dropdown        |
 | `ld-dashboard-date-zoom-dropdown`  | The open date-zoom menu          |
 | `ld-dashboard-parameter-dropdown`  | An open parameter's dropdown     |

--- a/references/react-sdk.mdx
+++ b/references/react-sdk.mdx
@@ -660,6 +660,35 @@ Sets the background for the embedded content. Can be any color value or `'transp
 />
 ```
 
+### CSS class overrides
+
+Beyond the `styles` prop, you can target embedded dashboard elements directly from your application's stylesheet. Each element below carries a stable, human-readable classname that is part of the SDK's public API — it won't change when internal layout does, so your overrides stay resilient across releases.
+
+| Class                              | Element                          |
+|------------------------------------|----------------------------------|
+| `ld-dashboard-header`              | The dashboard header bar         |
+| `ld-dashboard-filters`             | The filter bar row               |
+| `ld-dashboard-date-zoom`           | The date-zoom button             |
+| `ld-dashboard-parameters`          | The parameters row               |
+| `ld-dashboard-filter-dropdown`     | An open filter's dropdown        |
+| `ld-dashboard-date-zoom-dropdown`  | The open date-zoom menu          |
+| `ld-dashboard-parameter-dropdown`  | An open parameter's dropdown     |
+
+```css
+.ld-dashboard-filters {
+  gap: 1rem;
+}
+
+.ld-dashboard-filter-dropdown {
+  font-size: 1rem;
+  min-width: 380px;
+}
+```
+
+<Info>
+The filter, date-zoom, and parameter dropdowns render in a portal at the page root — outside the dashboard container — so target them with a global selector rather than as a descendant of the embedded dashboard.
+</Info>
+
 ## Light and dark mode
 
 Use the `theme` prop to render embedded content in either `'light'` or `'dark'` mode. This is typically driven by the host application's own theme state, so the embedded dashboard, chart, or explore matches the surrounding UI.


### PR DESCRIPTION
## Summary

Embedded dashboards now expose a set of stable, human-readable CSS classnames (the `ld-*` contract) that embedding customers can target to override styles — a reliable alternative to the hashed CSS-module classes that change between builds.

This documents them: a new "CSS class overrides" section in the React SDK reference (the full class table, a portal-targeting note, and the SDK-only caveat), plus a short pointer from the dashboard embedding guide.

Documents the feature added in lightdash/lightdash#24434. Should be merged once that ships in an SDK release, so the documented classnames exist in the published build.

Relates: PROD-3593
Relates: #20617