### PR TITLE
docs(timezones): document MIN/MAX date metric formatting

### DIFF
--- a/guides/developer/timezones.mdx
+++ b/guides/developer/timezones.mdx
@@ -103,6 +103,7 @@ This is the recommended way to configure the query timezone for most teams. It c
 - **Display** - table cells, chart axes, tooltips, and CSV/Excel/Google Sheets exports render timestamps in the project query timezone. A badge in the Explore view (when viewing or editing a saved chart) shows which timezone from the hierarchy is currently active.
 - **`DATE_TRUNC` grouping** - day, week, month, quarter, and year buckets align to the project query timezone calendar.
 - **Calendar extracts** - dimensions like "day of week", "month number", and "hour of day" are computed in the project query timezone, so they line up with their `DATE_TRUNC` siblings on the same row.
+- **MIN/MAX date metrics** - a `min`/`max` over a date column renders as an unshifted calendar date; over a timestamp column it shifts into the project query timezone. See [MIN/MAX metrics over date and timestamp columns](#minmax-metrics-over-date-and-timestamp-columns) below.
 - **Per-dimension opt-out** - individual dimensions can keep their raw warehouse value with `convert_timezone: false`. See [Per-dimension timezone opt-out](#per-dimension-timezone-opt-out) below.
 - **Date filter inputs** - the datetime picker in absolute date filters can be set to display and interpret values in the project query timezone, so the same typed value resolves to the same moment for every user regardless of their browser timezone. See [Date filter inputs in project timezone](#date-filter-inputs-in-project-timezone) below.
 
@@ -188,6 +189,21 @@ The override propagates to every auto-generated [time interval](/references/dime
 **What it changes:** display and grouping only - table cells, exports, `DATE_TRUNC` buckets, and calendar extracts all show the raw warehouse value.
 
 **What it doesn't change:** filters. Filters always use the project query timezone so every dimension on a row agrees on whether the row matches the filter. For example, a filter like `"between 2026-01-01 and 2026-01-31"` cuts at midnight in the project query timezone, even though the column itself renders raw.
+
+### MIN/MAX metrics over date and timestamp columns
+
+<Info>
+  **Beta:** Part of the project query timezone [Beta](/references/workspace/feature-maturity-levels). Contact support to enable it for your organization.
+</Info>
+
+A `min` or `max` metric renders based on the column it aggregates:
+
+- **Date column** (or a day-or-coarser date interval like `_month`) - rendered as a plain calendar date at that grain and never shifted.
+- **Timestamp column** - shifted into the project query timezone, like a timestamp dimension.
+
+<Note>
+  Custom `min`/`max` metrics built in the Explore view pick this up automatically. Metrics defined in dbt or Lightdash YAML need a **[Refresh dbt](/references/lightdash-cli#lightdash-refresh)** (or `lightdash deploy`) after upgrading before it applies.
+</Note>
 
 ### Data timezone
 

--- a/timezones-draft.mdx
+++ b/timezones-draft.mdx
@@ -211,6 +211,19 @@ A chart grouped by **hour, minute, or smaller** buckets data by instants. The bo
 
 **Implication:** sub-day grouping is naturally consistent across viewers. The only exception is half-hour and 45-minute offset zones (India, Nepal, parts of Australia), where bucket boundaries don't align with whole-hour zones. Hour-grain charts spanning a daylight-saving transition may also render with a one-hour visual jump at the boundary. *— [GLITCH-453](https://linear.app/lightdash/issue/GLITCH-453), [GLITCH-449](https://linear.app/lightdash/issue/GLITCH-449)*
 
+## MIN/MAX date and timestamp metrics
+
+A `min` or `max` metric renders by the type of the column it aggregates, the same calendar-vs-instant rule as dimensions:
+
+- **`DATE` column** (or a day-or-coarser date interval like `_month`): a plain calendar date at that grain, never shifted.
+- **`TIMESTAMP` column**: shifted into the resolved timezone, like a timestamp dimension.
+
+*— [GLITCH-499](https://linear.app/lightdash/issue/GLITCH-499)*
+
+<Note>
+**When it takes effect.** Custom MIN/MAX metrics built in the Explore view pick this up automatically. Metrics defined in dbt or Lightdash YAML need a project recompile (Refresh dbt / `lightdash deploy`) after the deploy before the new formatting applies. *— [GLITCH-499](https://linear.app/lightdash/issue/GLITCH-499)*
+</Note>
+
 ## Daylight-saving transitions
 
 Twice a year the clock jumps. In a DST zone like `America/New_York`, the **fall-back** day is 25 hours long (clocks go back, so 1 AM happens twice) and the **spring-forward** day is 23 hours long (clocks go forward, so 2 AM never happens). Lightdash buckets data in the project timezone, so these show up in your charts.


### PR DESCRIPTION
Documents how `min`/`max` metrics render under the project query timezone, from the GLITCH-499 stack ([#24445](https://github.com/lightdash/lightdash/pull/24445) → [#24446](https://github.com/lightdash/lightdash/pull/24446) → [#24447](https://github.com/lightdash/lightdash/pull/24447)).

## Changes
- **`guides/developer/timezones.mdx`** (published): new "MIN/MAX metrics over date and timestamp columns" section + a bullet in the Beta behaviors list.
- **`timezones-draft.mdx`**: matching section with the GLITCH-499 tag.

## What it covers
- A `min`/`max` over a **date** column renders as an unshifted calendar date; over a **timestamp** column it shifts into the project query timezone.
- When it takes effect: custom (Explore-built) metrics are automatic; dbt/YAML-defined metrics need a **Refresh dbt / `lightdash deploy`** to recompile before the new formatting applies.

Relates to GLITCH-499.