### PR TITLE
docs: document SDK content hooks

### DIFF
--- a/references/embedding.mdx
+++ b/references/embedding.mdx
@@ -62,7 +62,7 @@ All tokens share these fields:
 {
   content: {
     // Content configuration (required)
-    type: 'dashboard' | 'chart',
+    type: 'dashboard' | 'chart' | 'aiAgent' | 'apiAccess',
     projectUuid?: string,
     // ... type-specific fields
   },
@@ -303,6 +303,67 @@ const token = jwt.sign({
 }, SECRET, { expiresIn: '1h' });
 ```
 
+### API access token
+
+Use an API access token when your host app needs to call Lightdash APIs through the React SDK, for example to list spaces, dashboards, and charts with [`Lightdash.useLightdashContent`](/references/react-sdk#lightdashuselightdashcontent).
+
+```typescript
+{
+  content: {
+    type: 'apiAccess',
+
+    // Project identifier (required)
+    projectUuid: string,
+
+    // Service account used for permission checks (required)
+    serviceAccountUserUuid: string,
+  },
+
+  // Optional: row-level filtering for APIs that evaluate user attributes
+  userAttributes?: {
+    [attributeName: string]: string,
+  },
+
+  // Optional: user information surfaced in audit/analytics
+  user?: {
+    externalId?: string,
+    email?: string,
+  },
+}
+```
+
+<Info>
+API access tokens do not embed a specific dashboard or chart. They let the React SDK call supported Lightdash API endpoints with the permissions of `serviceAccountUserUuid`.
+</Info>
+
+**Example:**
+
+```javascript
+import jwt from 'jsonwebtoken';
+
+const token = jwt.sign({
+  content: {
+    type: 'apiAccess',
+    projectUuid: 'your-project-uuid',
+    serviceAccountUserUuid: 'service-account-user-uuid',
+  },
+  userAttributes: {
+    tenant_id: 'tenant-abc',
+  },
+  user: {
+    externalId: 'customer-user-123',
+    email: 'customer@example.com',
+  },
+}, SECRET, { expiresIn: '1h' });
+```
+
+**Rules:**
+
+- API access tokens must be generated server-side with your embed secret.
+- API access is authorized through the service account. The token can only list or read content that the service account can access.
+- A space UUID passed to an API hook is a filter, not a permission grant.
+- API access tokens cannot perform embed write actions. Use an embed token that supports `writeActions` when embedded users need to save charts or dashboards.
+
 ## Interactivity options reference
 
 ### Dashboard filters interactivity
@@ -514,6 +575,7 @@ writeActions?: {
 - When editing or building a dashboard, add-tile content is filtered to `spaceUuid`, so embedded users can only pick saved charts from the allowed space.
 - Dashboards and charts created or edited through write actions are normal Lightdash objects — they can be viewed and edited from Lightdash and vice versa.
 - Newly saved charts are **not** added to the embed allowlist automatically. They behave like normal private content and won't be re-embeddable unless you add them explicitly.
+- API access tokens do not support write actions. They are for supported API reads, such as listing content through the React SDK.
 
 ### Configure write actions
 

--- a/references/react-sdk.mdx
+++ b/references/react-sdk.mdx
@@ -81,15 +81,16 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 The CSS import must be the first import in your entry file to ensure Lightdash styles load before other styles and avoid conflicts.
 </Warning>
 
-## Components
+## Components and hooks
 
-The Lightdash SDK exports five components for embedding different content types:
+The Lightdash SDK exports components for embedding Lightdash content and hooks for building custom host-app UI around embedded content:
 
 - `Lightdash.Dashboard` - Embed complete dashboards with multiple tiles
 - `Lightdash.DashboardBuilder` - Let embedded users create a brand-new dashboard
 - `Lightdash.Chart` - Embed individual saved charts
 - `Lightdash.Explore` - Embed interactive data exploration interface
 - `Lightdash.AiAgent` - Embed an AI agent so users can chat with their data
+- `Lightdash.useLightdashContent` - List spaces, dashboards, charts, and data apps for a custom content catalog
 
 All components share common props for authentication and styling.
 
@@ -529,6 +530,123 @@ export function generateAiAgentToken() {
 ```
 
 See [Embedding AI agents](/guides/embedding/ai-agents) for the full guide and [AI agent token](/references/embedding#ai-agent-token) for the complete JWT structure.
+
+## API hooks
+
+### Lightdash.useLightdashContent
+
+Use `useLightdashContent` when you want your own app to list Lightdash content instead of embedding the Lightdash home page. A common pattern is to let customers choose a space in your UI, show the dashboards and charts in that space, then render the selected object with `Lightdash.Dashboard` or `Lightdash.Chart`.
+
+The hook calls the Lightdash content API and returns metadata only. It does not render the selected chart or dashboard, and it does not replace the chart or dashboard embed token you pass to the render component.
+
+#### Backend: generate an API access token
+
+Generate the token on your backend with your Lightdash embed secret. Never expose the embed secret in browser code.
+
+```typescript
+import jwt from 'jsonwebtoken';
+
+export function generateContentCatalogToken() {
+  return jwt.sign(
+    {
+      content: {
+        type: 'apiAccess',
+        projectUuid: 'your-project-uuid',
+        serviceAccountUserUuid: 'service-account-user-uuid',
+      },
+      user: {
+        externalId: 'customer-user-123',
+        email: 'customer@example.com',
+      },
+      userAttributes: {
+        tenant_id: 'tenant-abc',
+      },
+    },
+    process.env.LIGHTDASH_EMBED_SECRET,
+    { expiresIn: '1h' },
+  );
+}
+```
+
+The service account controls what the hook can list. If the service account cannot view a private space, content from that space is not returned.
+
+#### Frontend: list content in a space
+
+```tsx
+import Lightdash from '@lightdash/sdk';
+
+function ContentCatalog({
+  instanceUrl,
+  projectUuid,
+  token,
+  spaceUuid,
+}: {
+  instanceUrl: string;
+  projectUuid: string;
+  token: string;
+  spaceUuid: string;
+}) {
+  const { data, error, isLoading, refetch } = Lightdash.useLightdashContent(
+    {
+      instanceUrl,
+      projectUuid,
+      auth: {
+        type: 'embedToken',
+        token,
+      },
+    },
+    {
+      spaceUuids: [spaceUuid],
+      contentTypes: ['dashboard', 'chart'],
+      page: 1,
+      pageSize: 50,
+      sortBy: 'name',
+      sortDirection: 'asc',
+    },
+  );
+
+  if (isLoading) return <p>Loading content...</p>;
+  if (error) return <p>Unable to load content</p>;
+
+  return (
+    <div>
+      <button type="button" onClick={() => refetch()}>
+        Refresh
+      </button>
+
+      {data?.data.map((item) => (
+        <button key={item.uuid} type="button">
+          {item.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+#### Options
+
+```typescript
+type ListContentOptions = {
+  projectUuids?: string[];
+  spaceUuids?: string[];
+  parentSpaceUuid?: string;
+  contentTypes?: Array<'space' | 'dashboard' | 'chart' | 'data_app'>;
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  sortBy?: 'name' | 'space_name' | 'last_updated_at';
+  sortDirection?: 'asc' | 'desc';
+};
+```
+
+<Info>
+Use the `spaceUuids` option as a filter, not as an authorization boundary. Authorization comes from the API access token's service account permissions.
+</Info>
+
+<Warning>
+`apiAccess` tokens are for API reads such as content listing. To let embedded users save charts or dashboards, use an embed token that supports `writeActions`.
+</Warning>
 
 ## Generating embed tokens
 


### PR DESCRIPTION
## Summary
- Document the React SDK content catalog hook and copy-paste usage pattern
- Add the apiAccess embed token reference and service-account permission model
- Clarify that apiAccess is read-only and that space UUIDs are filters, not permission grants

## Testing
- git diff --check

Relates: lightdash/lightdash#24449