### PR TITLE
docs: add AWS IAM authentication guide for Redshift

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -377,15 +377,15 @@ Enable if you're connecting to a Redshift Serverless workgroup rather than a pro
 
 ##### Assume role ARN
 
-Recommended. An IAM role Lightdash assumes to mint Redshift credentials. Leave blank to use the host's IAM role (self-hosted only), or provide AWS access keys under Advanced.
+Optional. An IAM role to assume — within your own AWS account — before minting credentials, instead of using the access-key identity directly. Self-hosted instances running on AWS can leave this and the access keys blank to use the host's IAM role.
 
 ##### Assume role external ID
 
-The external ID required by the assume-role trust policy, if you configured one.
+The external ID required by the role's trust policy, if you configured one.
 
 ##### Advanced: AWS access key ID & secret access key
 
-A static IAM user access key, used only if you are not assuming a role or relying on the host's IAM role. This is a long-lived secret — prefer assume-role where possible.
+The access key for the IAM user Lightdash uses to mint temporary Redshift credentials. On Lightdash Cloud, this is how you provide the AWS identity.
 
 ##### Advanced: Auto-create database user
 
@@ -428,27 +428,15 @@ Serverless workgroup:
 }
 ```
 
-**2. Give Lightdash an identity.** Choose one:
+**2. Create an identity to call that API.**
 
-- **Assume role (recommended).** Create an IAM role, attach the policy above, and add a trust policy allowing Lightdash to assume it. Pick any external ID string — it acts as a shared secret so only Lightdash can assume the role — and enter the role ARN and external ID in Lightdash.
+- **Access keys (Lightdash Cloud).** Create an IAM user, attach the policy above, generate an access key and secret, and enter them under **Advanced** on the connection form. Lightdash Cloud has no AWS identity of its own, so this is how you grant access. Keep the policy minimal and rotate the key periodically.
 
-  ```json
-  {
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Principal": { "AWS": "<LIGHTDASH_AWS_PRINCIPAL>" },
-      "Action": "sts:AssumeRole",
-      "Condition": { "StringEquals": { "sts:ExternalId": "<your-external-id>" } }
-    }]
-  }
-  ```
+- **Assume role (optional).** If you'd rather not grant the IAM user the Redshift permissions directly, attach the policy to a separate IAM role and let the user assume it: add a trust policy on the role allowing that user to assume it, then enter the role ARN (and external ID, if set) on the form. The role is assumed **within your own AWS account** — there is no cross-account trust with Lightdash.
 
-- **Access keys.** Create an IAM user with the policy above, generate an access key and secret, and enter them under **Advanced**. This is a long-lived secret — prefer assume-role.
+- **Host role (self-hosted on AWS only).** If you run Lightdash yourself on AWS, attach the policy to the instance or task role (EC2 instance profile, ECS task role, or IRSA) and leave the access-key and role fields blank.
 
-- **Host role (self-hosted only).** If Lightdash runs on AWS with an attached instance role or IRSA, attach the policy there and leave all credential fields blank.
-
-**3. Configure the connection** in Lightdash: set **Authentication type** to **AWS IAM**, fill in region, cluster/workgroup, database user, and your chosen identity, then click **Test & save**.
+**3. Configure the connection** in Lightdash: set **Authentication type** to **AWS IAM**, fill in region, cluster/workgroup, database user, and your access keys, then click **Test & save**.
 
 </Accordion>
 

--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -393,6 +393,10 @@ The access key for the IAM user Lightdash uses to mint temporary Redshift creden
 
 <Accordion title="Setting up AWS IAM for Redshift">
 
+<Note>
+  IAM changes how Lightdash **authenticates**, not how it **reaches** your warehouse. Lightdash still opens a network connection to your cluster, so its [static IP addresses](#adding-lightdashs-static-ip-addresses-to-your-allow-list) must be allow-listed in your Redshift security group or VPC firewall (or use an SSH tunnel), exactly as with password authentication. Minting credentials happens over public AWS API endpoints and needs no extra allow-listing.
+</Note>
+
 **1. Create an IAM policy** that allows minting credentials. Use the variant for your warehouse type.
 
 Provisioned cluster:

--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -347,6 +347,111 @@ This controls what day is the start of the week in Lightdash. `Auto` sets it to 
 
 Enable to input your **SSH Remote Host**, **SSH Remote Port**, **SSH Username**, and to generate a public SSH key.
 
+##### Authentication type
+
+By default Lightdash connects to Redshift with a database **username and password**. You can instead authenticate with **AWS IAM**: Lightdash assumes an AWS identity and mints short-lived database credentials (valid up to 1 hour) from AWS at connection time, then connects over the standard Postgres protocol. No long-lived database password is stored. This is useful when your security policy disallows static or hashed passwords, or when your cluster fronts Lake Formation.
+
+<Note>If you don't see the **AWS IAM** option, it isn't enabled for your organization yet — contact Lightdash support.</Note>
+
+When **Authentication type** is set to **AWS IAM**, the following fields replace the password. Your **Host**, **DB name**, **Schema**, SSL, and SSH tunnel settings still apply.
+
+##### AWS region
+
+The AWS region where your Redshift cluster or serverless workgroup is located, for example `us-east-1`.
+
+##### Redshift Serverless
+
+Enable if you're connecting to a Redshift Serverless workgroup rather than a provisioned cluster.
+
+##### Cluster identifier
+
+(Provisioned clusters) The identifier of your Redshift cluster.
+
+##### Workgroup name
+
+(Serverless) The name of your Redshift Serverless workgroup.
+
+##### Database user
+
+(Provisioned clusters) The Redshift database user to request temporary credentials for. Serverless derives the user automatically.
+
+##### Assume role ARN
+
+Recommended. An IAM role Lightdash assumes to mint Redshift credentials. Leave blank to use the host's IAM role (self-hosted only), or provide AWS access keys under Advanced.
+
+##### Assume role external ID
+
+The external ID required by the assume-role trust policy, if you configured one.
+
+##### Advanced: AWS access key ID & secret access key
+
+A static IAM user access key, used only if you are not assuming a role or relying on the host's IAM role. This is a long-lived secret — prefer assume-role where possible.
+
+##### Advanced: Auto-create database user
+
+(Provisioned clusters) Create the database user automatically if it does not already exist.
+
+<Accordion title="Setting up AWS IAM for Redshift">
+
+**1. Create an IAM policy** that allows minting credentials. Use the variant for your warehouse type.
+
+Provisioned cluster:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "LightdashRedshiftCredentials",
+    "Effect": "Allow",
+    "Action": "redshift:GetClusterCredentials",
+    "Resource": [
+      "arn:aws:redshift:<region>:<account-id>:dbuser:<cluster-identifier>/<db-user>",
+      "arn:aws:redshift:<region>:<account-id>:dbname:<cluster-identifier>/<db-name>"
+    ]
+  }]
+}
+```
+
+If you enable **Auto-create database user**, also allow `redshift:CreateClusterUser` on the `dbuser:` resource. If you use database groups, add `redshift:JoinGroup` on the relevant `dbgroup:` resources.
+
+Serverless workgroup:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "LightdashRedshiftServerlessCredentials",
+    "Effect": "Allow",
+    "Action": "redshift-serverless:GetCredentials",
+    "Resource": "arn:aws:redshift-serverless:<region>:<account-id>:workgroup/<workgroup-id>"
+  }]
+}
+```
+
+**2. Give Lightdash an identity.** Choose one:
+
+- **Assume role (recommended).** Create an IAM role, attach the policy above, and add a trust policy allowing Lightdash to assume it. Pick any external ID string — it guards against confused-deputy access — and enter the role ARN and external ID in Lightdash.
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": { "AWS": "<LIGHTDASH_AWS_PRINCIPAL>" },
+      "Action": "sts:AssumeRole",
+      "Condition": { "StringEquals": { "sts:ExternalId": "<your-external-id>" } }
+    }]
+  }
+  ```
+
+- **Access keys.** Create an IAM user with the policy above, generate an access key and secret, and enter them under **Advanced**. This is a long-lived secret — prefer assume-role.
+
+- **Host role (self-hosted only).** If Lightdash runs on AWS with an attached instance role or IRSA, attach the policy there and leave all credential fields blank.
+
+**3. Configure the connection** in Lightdash: set **Authentication type** to **AWS IAM**, fill in region, cluster/workgroup, database user, and your chosen identity, then click **Test & save**.
+
+</Accordion>
+
 ***
 
 

--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -440,7 +440,7 @@ Serverless workgroup:
 
 - **Host role (self-hosted on AWS only).** If you run Lightdash yourself on AWS, attach the policy to the instance or task role (EC2 instance profile, ECS task role, or IRSA) and leave the access-key and role fields blank.
 
-**3. Configure the connection** in Lightdash: set **Authentication type** to **AWS IAM**, fill in region, cluster/workgroup, database user, and your access keys, then click **Test & save**.
+**3. Configure the connection in Lightdash.** Open your project's connection settings — [**Project settings** via the gear icon in the top-right navigation](#open-up-your-lightdash-instance-to-get-started) for an existing project, or **Organization settings → All projects → Create new** for a new one. In the Redshift form, switch **Authentication type** to **AWS IAM** (this reveals the AWS fields), then fill in the **AWS region**, **cluster identifier** (or serverless **workgroup name**), **database user**, and your access keys under **Advanced**, and click **Test & save**.
 
 </Accordion>
 

--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -430,7 +430,7 @@ Serverless workgroup:
 
 **2. Give Lightdash an identity.** Choose one:
 
-- **Assume role (recommended).** Create an IAM role, attach the policy above, and add a trust policy allowing Lightdash to assume it. Pick any external ID string — it guards against confused-deputy access — and enter the role ARN and external ID in Lightdash.
+- **Assume role (recommended).** Create an IAM role, attach the policy above, and add a trust policy allowing Lightdash to assume it. Pick any external ID string — it acts as a shared secret so only Lightdash can assume the role — and enter the role ARN and external ID in Lightdash.
 
   ```json
   {


### PR DESCRIPTION
Adds an **AWS IAM authentication** subsection to the Redshift section of the Connect a project guide, covering the new auth option shipped in lightdash/lightdash#24566.

## What's documented
- How IAM auth works (Lightdash mints short-lived DB credentials via AWS, no stored DB password)
- The new connection-form fields: region, Redshift Serverless toggle, cluster identifier / workgroup name, database user, assume-role ARN + external ID, advanced access keys, auto-create user
- A "Setting up AWS IAM for Redshift" accordion: IAM policy examples (provisioned + serverless) and how to provide the AWS identity

## Auth model (important)
Lightdash Cloud runs on GCP and has **no AWS identity of its own**, so:
- **Access keys** is the primary path for Cloud (a dedicated least-privilege IAM user) — mirrors how Athena works on Cloud.
- **Assume-role** is documented only as an optional **intra-account** hop (the customer's own user assuming the customer's own role). There is no cross-account "trust Lightdash" model, so the earlier `<LIGHTDASH_AWS_PRINCIPAL>` trust-policy placeholder has been removed.
- **Host role** is labelled self-hosted-on-AWS only.

## Follow-up (separate, not this PR)
The in-product description for the **Assume role ARN** field still reads "Recommended… an IAM role Lightdash assumes… leave blank to use the host's IAM role," which implies an AWS-hosted model and is misleading on Cloud. Worth a small copy tweak in `RedshiftForm.tsx` to match this guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)