### PR TITLE
docs: remove cross-account trust mention from Redshift IAM guide

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -436,7 +436,7 @@ Serverless workgroup:
 
 - **Access keys (Lightdash Cloud).** Create an IAM user, attach the policy above, generate an access key and secret, and enter them under **Advanced** on the connection form. Lightdash Cloud has no AWS identity of its own, so this is how you grant access. Keep the policy minimal and rotate the key periodically.
 
-- **Assume role (optional).** If you'd rather not grant the IAM user the Redshift permissions directly, attach the policy to a separate IAM role and let the user assume it: add a trust policy on the role allowing that user to assume it, then enter the role ARN (and external ID, if set) on the form. The role is assumed **within your own AWS account** — there is no cross-account trust with Lightdash.
+- **Assume role (optional).** If you'd rather not grant the IAM user the Redshift permissions directly, attach the policy to a separate IAM role and let the user assume it: add a trust policy on the role allowing that user to assume it, then enter the role ARN (and external ID, if set) on the form. The role is assumed **within your own AWS account**.
 
 - **Host role (self-hosted on AWS only).** If you run Lightdash yourself on AWS, attach the policy to the instance or task role (EC2 instance profile, ECS task role, or IRSA) and leave the access-key and role fields blank.
 


### PR DESCRIPTION
Follow-up to #884. Removes the "there is no cross-account trust with Lightdash" clause from the Redshift IAM **Assume role (optional)** note.

The assume-role option is an intra-account hop (the customer's own user assuming the customer's own role); calling out a cross-account model we don't offer added noise. The sentence now just states the role is assumed within the customer's own AWS account.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)