### PR TITLE
Add instance health best practices guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,6 +96,7 @@
                   "guides/version-history",
                   "guides/how-to-promote-content",
                   "guides/verified-content",
+                  "guides/instance-health-best-practices",
                   "guides/keyboard-shortcuts",
                   {
                     "group": "Table calculations",

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -1,49 +1,80 @@
 ---
 title: "Instance health best practices"
-description: "How to keep a Lightdash deployment adopted, governed, and cost-efficient."
+sidebarTitle: Instance health
+description: How to keep a Lightdash deployment adopted, governed, and cost-efficient. These are the practices a Lightdash instance health review grades against, with what good looks like, why it matters, and a review cadence for each.
 ---
 
-A healthy Lightdash deployment is adopted by the people who need it, governed so access
-and content stay trustworthy, and efficient so warehouse cost tracks value. These are the
-practices the Instance Health Audit grades against.
+A healthy Lightdash deployment is adopted by the people who need it, governed so access and content stay trustworthy, and efficient so warehouse cost tracks the value it returns. This guide sets out what good looks like across those three areas, why each one matters, and how often to review it.
+
+If your team has run a Lightdash instance health review, the recommendations in that report link back to the sections below.
+
+<CardGroup cols={2}>
+  <Card title="Adoption" icon="users" href="#adoption">
+    Are the right people using Lightdash, and staying active?
+  </Card>
+  <Card title="Access governance" icon="lock" href="#access-governance">
+    Is access granted safely and kept current?
+  </Card>
+  <Card title="Content lifecycle" icon="arrows-rotate" href="#content-lifecycle">
+    Is content trustworthy, owned, and free of clutter?
+  </Card>
+  <Card title="Cost and performance" icon="gauge-high" href="#cost-and-performance">
+    Is warehouse spend tracking the value returned?
+  </Card>
+</CardGroup>
 
 ## Adoption
 
-Good looks like: a majority of provisioned users run at least one query every 90 days,
-weekly-to-monthly stickiness above 40%, and no cohort of users who were active and then
-went silent. Why it matters: inactive licensed seats are paid capacity returning no value,
-and lapsed users are an early churn signal; decisions get made without the data.
+Adoption measures whether the people provisioned in Lightdash are actually using it, and whether anyone who was active has quietly dropped off.
 
-Practice: review usage monthly. When a team's activation drops, run a short enablement
-session focused on the spaces they already use, and appoint a champion to follow up.
+**What good looks like:** most provisioned users run at least one query every 90 days, weekly-to-monthly stickiness sits above 40%, and there is no cohort of users who were active and then went silent.
+
+Inactive licensed seats are paid capacity returning no value, and lapsed users are an early churn signal: when someone stops querying, decisions in their team start getting made without the data. Tracking adoption by team (using [groups](/references/workspace/groups)) shows you where to focus enablement, rather than treating the instance as one undifferentiated number.
+
+<Tip>
+Review usage monthly. When a team's activation drops, run a short enablement session focused on the spaces they already use, and appoint a champion to follow up. [Usage analytics](/references/workspace/usage-analytics) gives you the activation and engagement numbers to track.
+</Tip>
 
 ## Access governance
 
-Good looks like: access granted through Groups rather than per-user, admins kept to a small
-active set, no personal access tokens without an expiry, and no content owned by deactivated
-users. Why it matters: over-broad access and no-expiry tokens are standing security risk,
-and orphaned content erodes trust in what is current.
+Governance keeps access and credentials safe as your team and content grow.
 
-Practice: review access quarterly. Manage project and space access via Groups so
-onboarding and offboarding are atomic. Set a maximum token expiry
-(`PAT_MAX_EXPIRATION_TIME_IN_DAYS`); note this blocks new no-expiry tokens but does not
-retroactively revoke existing ones, which must be rotated manually.
+**What good looks like:** access is granted through [groups](/references/workspace/groups) rather than per user, admins are kept to a small active set, no [personal access tokens](/references/workspace/personal-tokens) are left without an expiry, and no content is owned by deactivated users.
+
+Over-broad access and tokens that never expire are a standing security risk, and content orphaned by a departed owner erodes trust in what is current. Managing access through groups also makes onboarding and offboarding atomic: add or remove a person once, and their access follows.
+
+<Tip>
+Review access quarterly. Grant project and space access via [groups](/references/workspace/groups) and [roles](/references/workspace/roles), and rotate stale tokens.
+</Tip>
+
+<Info>
+Setting a maximum token lifetime (`PAT_MAX_EXPIRATION_TIME_IN_DAYS`) blocks new tokens from being created without an expiry. On self-hosted instances this is an [environment variable](/self-host/customize-deployment/environment-variables); on Cloud, request it from Lightdash support. It does not retroactively revoke existing no-expiry tokens, so any already created must be rotated or revoked manually.
+</Info>
 
 ## Content lifecycle
 
-Good looks like: little or no content with zero views, and spaces with named owners. Why it
-matters: stale and duplicated content drives shadow reporting and undermines confidence in
-the numbers, and dead-but-scheduled content wastes warehouse cost.
+Content lifecycle is about keeping what your team sees trustworthy, owned, and free of clutter.
 
-Practice: review content quarterly. Archive unused dashboards and charts into a dedicated
-archive space, and give every active space a named owner.
+**What good looks like:** little or no content with zero views, every active [space](/references/workspace/spaces) has a named owner, and the canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust.
+
+Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, owned, verified content set is what lets new users (and AI agents) start from the right place.
+
+<Tip>
+Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, give every active space a named owner, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
+</Tip>
 
 ## Cost and performance
 
-Good looks like: p95 query latency within target, a low error rate, and no single explore
-dominating warehouse time. Why it matters: a few heavy explores or failing scheduled
-deliveries can account for a disproportionate share of spend and degrade the experience for
-everyone.
+This area keeps query performance healthy and warehouse spend proportional to the value Lightdash returns.
 
-Practice: review cost monthly. Investigate the heaviest explores with your data team for
-missing aggregations or overly broad filters, and prune or fix failing scheduled deliveries.
+**What good looks like:** p95 query latency is within your target, the error rate is low, and no single explore dominates warehouse time.
+
+A handful of heavy explores or failing scheduled deliveries can account for a disproportionate share of spend and slow the experience for everyone. Watching cost by explore, user, and context tells you where to optimise instead of guessing.
+
+<Tip>
+Review cost monthly. Investigate the heaviest explores with your data team for missing aggregations or overly broad filters, and prune or fix failing [scheduled deliveries](/guides/how-to-create-scheduled-deliveries).
+</Tip>
+
+<Note>
+These practices map to the sections of a Lightdash instance health review. If you have run one, work the report's action plan from top to bottom: it is ordered by priority and links each recommendation back to the relevant section above.
+</Note>

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -1,16 +1,20 @@
 ---
 title: "Instance health best practices"
 sidebarTitle: Instance health
-description: How to keep a Lightdash deployment adopted, governed, and cost-efficient. These are the practices a Lightdash instance health review grades against, with what good looks like, why it matters, and a review cadence for each.
+description: How to keep a Lightdash deployment relevant, governed, and performant. These are the practices a Lightdash instance health review grades against, with what good looks like, why it matters, and further guidance for each.
 ---
 
 A healthy Lightdash deployment is adopted by the people who need it, governed so access and content stay trustworthy, and efficient so warehouse cost tracks the value it returns. This guide sets out what good looks like across those three areas, why each one matters, and how often to review it.
 
 If your team has run a Lightdash instance health review, the recommendations in that report link back to the sections below.
 
+<Info>
+You can request a Lightdash Instance Health review as part of the Enterprise plan. [View pricing](https://www.lightdash.com/pricing)
+</Info>
+
 <CardGroup cols={2}>
   <Card title="Adoption" icon="users" href="#adoption">
-    Are the right people using Lightdash, and staying active?
+    Are people signing up to Lightdash, and staying active once they're there?
   </Card>
   <Card title="Access governance" icon="lock" href="#access-governance">
     Is access granted safely and kept current?
@@ -29,7 +33,7 @@ Adoption measures whether the people provisioned in Lightdash are actually using
 
 **What good looks like:** most provisioned users run at least one query every 90 days, weekly-to-monthly stickiness sits above 40%, and there is no cohort of users who were active and then went silent.
 
-Inactive licensed seats are paid capacity returning no value, and lapsed users are an early churn signal: when someone stops querying, decisions in their team start getting made without the data. Tracking adoption by team (using [groups](/references/workspace/groups)) shows you where to focus enablement, rather than treating the instance as one undifferentiated number.
+Lapsed users are an early signal that something isn't working for your instance. When someone stops querying, decisions in their team start getting made without the data. Tracking adoption by team (using [groups](/references/workspace/groups)) shows you where to focus enablement, rather than treating the instance as one undifferentiated number.
 
 <Tip>
 Review usage monthly. When a team's activation drops, run a short enablement session focused on the spaces they already use, and appoint a champion to follow up. [Usage analytics](/references/workspace/usage-analytics) gives you the activation and engagement numbers to track.
@@ -55,12 +59,12 @@ Setting a maximum token lifetime (`PAT_MAX_EXPIRATION_TIME_IN_DAYS`) blocks new 
 
 Content lifecycle is about keeping what your team sees trustworthy, owned, and free of clutter.
 
-**What good looks like:** little or no content with zero views, every active [space](/references/workspace/spaces) has a named owner, and the canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust.
+**What good looks like:** little or no content with zero views, every active [space](/references/workspace/spaces) has a clear owner, and the canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust.
 
 Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, owned, verified content set is what lets new users (and AI agents) start from the right place.
 
 <Tip>
-Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, give every active space a named owner, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
+Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, give every active space an owner, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
 </Tip>
 
 ## Cost and performance

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -71,13 +71,13 @@ Content lifecycle is about keeping what your team sees trustworthy, maintained, 
 **What good looks like:**
 
 - Little or no content with zero views
-- Every active [space](/references/workspace/spaces) has an admin who maintains it
+- Each active [space](/references/workspace/spaces) is aligned to a [group](/references/workspace/groups), so a team is clearly responsible for it
 - The canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust
 
 Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, maintained, verified content set is what lets new users (and AI agents) start from the right place.
 
 <Tip>
-Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, make sure each active space has an admin who maintains it, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
+Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, align each active space to the [group](/references/workspace/groups) responsible for it, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
 </Tip>
 
 ## Cost and performance

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -20,7 +20,7 @@ You can request a Lightdash Instance Health review as part of the Enterprise pla
     Is access granted safely and kept current?
   </Card>
   <Card title="Content lifecycle" icon="arrows-rotate" href="#content-lifecycle">
-    Is content trustworthy, owned, and free of clutter?
+    Is content trustworthy, maintained, and free of clutter?
   </Card>
   <Card title="Cost and performance" icon="gauge-high" href="#cost-and-performance">
     Is warehouse spend tracking the value returned?
@@ -52,9 +52,9 @@ Governance keeps access and credentials safe as your team and content grow.
 - Access is granted through [groups](/references/workspace/groups) rather than per user
 - Admins are kept to a small active set
 - No [personal access tokens](/references/workspace/personal-tokens) are left without an expiry
-- No content is owned by deactivated users
+- Content created by people who have left is reviewed and archived, not left to drift
 
-Over-broad access and tokens that never expire are a standing security risk, and content orphaned by a departed owner erodes trust in what is current. Managing access through groups also makes onboarding and offboarding atomic: add or remove a person once, and their access follows.
+Over-broad access and tokens that never expire are a standing security risk, and content left behind when people leave erodes trust in what is current. Managing access through groups also makes onboarding and offboarding atomic: add or remove a person once, and their access follows.
 
 <Tip>
 Review access quarterly. Grant project and space access via [groups](/references/workspace/groups) and [roles](/references/workspace/roles), and rotate stale tokens.
@@ -66,18 +66,18 @@ Setting a maximum token lifetime (`PAT_MAX_EXPIRATION_TIME_IN_DAYS`) blocks new 
 
 ## Content lifecycle
 
-Content lifecycle is about keeping what your team sees trustworthy, owned, and free of clutter.
+Content lifecycle is about keeping what your team sees trustworthy, maintained, and free of clutter.
 
 **What good looks like:**
 
 - Little or no content with zero views
-- Every active [space](/references/workspace/spaces) has a clear owner
+- Every active [space](/references/workspace/spaces) has an admin who maintains it
 - The canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust
 
-Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, owned, verified content set is what lets new users (and AI agents) start from the right place.
+Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, maintained, verified content set is what lets new users (and AI agents) start from the right place.
 
 <Tip>
-Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, give every active space an owner, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
+Review content quarterly. Archive unused dashboards and charts into a dedicated archive space, make sure each active space has an admin who maintains it, and [verify](/guides/verified-content) the content you want people to start from. When moving content between projects, use [content promotion](/guides/how-to-promote-content).
 </Tip>
 
 ## Cost and performance

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -1,0 +1,49 @@
+---
+title: "Instance health best practices"
+description: "How to keep a Lightdash deployment adopted, governed, and cost-efficient."
+---
+
+A healthy Lightdash deployment is adopted by the people who need it, governed so access
+and content stay trustworthy, and efficient so warehouse cost tracks value. These are the
+practices the Instance Health Audit grades against.
+
+## Adoption
+
+Good looks like: a majority of provisioned users run at least one query every 90 days,
+weekly-to-monthly stickiness above 40%, and no cohort of users who were active and then
+went silent. Why it matters: inactive licensed seats are paid capacity returning no value,
+and lapsed users are an early churn signal; decisions get made without the data.
+
+Practice: review usage monthly. When a team's activation drops, run a short enablement
+session focused on the spaces they already use, and appoint a champion to follow up.
+
+## Access governance
+
+Good looks like: access granted through Groups rather than per-user, admins kept to a small
+active set, no personal access tokens without an expiry, and no content owned by deactivated
+users. Why it matters: over-broad access and no-expiry tokens are standing security risk,
+and orphaned content erodes trust in what is current.
+
+Practice: review access quarterly. Manage project and space access via Groups so
+onboarding and offboarding are atomic. Set a maximum token expiry
+(`PAT_MAX_EXPIRATION_TIME_IN_DAYS`); note this blocks new no-expiry tokens but does not
+retroactively revoke existing ones, which must be rotated manually.
+
+## Content lifecycle
+
+Good looks like: little or no content with zero views, and spaces with named owners. Why it
+matters: stale and duplicated content drives shadow reporting and undermines confidence in
+the numbers, and dead-but-scheduled content wastes warehouse cost.
+
+Practice: review content quarterly. Archive unused dashboards and charts into a dedicated
+archive space, and give every active space a named owner.
+
+## Cost and performance
+
+Good looks like: p95 query latency within target, a low error rate, and no single explore
+dominating warehouse time. Why it matters: a few heavy explores or failing scheduled
+deliveries can account for a disproportionate share of spend and degrade the experience for
+everyone.
+
+Practice: review cost monthly. Investigate the heaviest explores with your data team for
+missing aggregations or overly broad filters, and prune or fix failing scheduled deliveries.

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -31,7 +31,11 @@ You can request a Lightdash Instance Health review as part of the Enterprise pla
 
 Adoption measures whether the people provisioned in Lightdash are actually using it, and whether anyone who was active has quietly dropped off.
 
-**What good looks like:** most provisioned users run at least one query every 90 days, weekly-to-monthly stickiness sits above 40%, and there is no cohort of users who were active and then went silent.
+**What good looks like:**
+
+- Most provisioned users run at least one query every 90 days
+- Weekly-to-monthly stickiness sits above 40%
+- No cohort of users who were active and then went silent
 
 Lapsed users are an early signal that something isn't working for your instance. When someone stops querying, decisions in their team start getting made without the data. Tracking adoption by team (using [groups](/references/workspace/groups)) shows you where to focus enablement, rather than treating the instance as one undifferentiated number.
 
@@ -43,7 +47,12 @@ Review usage monthly. When a team's activation drops, run a short enablement ses
 
 Governance keeps access and credentials safe as your team and content grow.
 
-**What good looks like:** access is granted through [groups](/references/workspace/groups) rather than per user, admins are kept to a small active set, no [personal access tokens](/references/workspace/personal-tokens) are left without an expiry, and no content is owned by deactivated users.
+**What good looks like:**
+
+- Access is granted through [groups](/references/workspace/groups) rather than per user
+- Admins are kept to a small active set
+- No [personal access tokens](/references/workspace/personal-tokens) are left without an expiry
+- No content is owned by deactivated users
 
 Over-broad access and tokens that never expire are a standing security risk, and content orphaned by a departed owner erodes trust in what is current. Managing access through groups also makes onboarding and offboarding atomic: add or remove a person once, and their access follows.
 
@@ -59,7 +68,11 @@ Setting a maximum token lifetime (`PAT_MAX_EXPIRATION_TIME_IN_DAYS`) blocks new 
 
 Content lifecycle is about keeping what your team sees trustworthy, owned, and free of clutter.
 
-**What good looks like:** little or no content with zero views, every active [space](/references/workspace/spaces) has a clear owner, and the canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust.
+**What good looks like:**
+
+- Little or no content with zero views
+- Every active [space](/references/workspace/spaces) has a clear owner
+- The canonical charts and dashboards are marked as [verified](/guides/verified-content) so people know what to trust
 
 Stale and duplicated content drives shadow reporting and undermines confidence in the numbers; dead content that is still on a [scheduled delivery](/guides/how-to-create-scheduled-deliveries) also wastes warehouse cost. A tidy, owned, verified content set is what lets new users (and AI agents) start from the right place.
 
@@ -71,7 +84,11 @@ Review content quarterly. Archive unused dashboards and charts into a dedicated 
 
 This area keeps query performance healthy and warehouse spend proportional to the value Lightdash returns.
 
-**What good looks like:** p95 query latency is within your target, the error rate is low, and no single explore dominates warehouse time.
+**What good looks like:**
+
+- p95 query latency is within your target
+- The error rate is low
+- No single explore dominates warehouse time
 
 A handful of heavy explores or failing scheduled deliveries can account for a disproportionate share of spend and slow the experience for everyone. Watching cost by explore, user, and context tells you where to optimise instead of guessing.
 

--- a/guides/instance-health-best-practices.mdx
+++ b/guides/instance-health-best-practices.mdx
@@ -6,8 +6,6 @@ description: How to keep a Lightdash deployment relevant, governed, and performa
 
 A healthy Lightdash deployment is adopted by the people who need it, governed so access and content stay trustworthy, and efficient so warehouse cost tracks the value it returns. This guide sets out what good looks like across those three areas, why each one matters, and how often to review it.
 
-If your team has run a Lightdash instance health review, the recommendations in that report link back to the sections below.
-
 <Info>
 You can request a Lightdash Instance Health review as part of the Enterprise plan. [View pricing](https://www.lightdash.com/pricing)
 </Info>
@@ -66,7 +64,7 @@ Setting a maximum token lifetime (`PAT_MAX_EXPIRATION_TIME_IN_DAYS`) blocks new 
 
 ## Content lifecycle
 
-Content lifecycle is about keeping what your team sees trustworthy, maintained, and free of clutter.
+Content lifecycle is about keeping your charts and dashboards current and easy to navigate, so people trust what they find.
 
 **What good looks like:**
 


### PR DESCRIPTION
## What

Adds a new customer-facing guide at `guides/instance-health-best-practices` covering how to keep a Lightdash deployment adopted, governed, and cost-efficient — with four sections (Adoption, Access governance, Content lifecycle, Cost and performance), each stating what good looks like, why it matters, and a concrete cadence.

## Why

This is the citable source of truth that the new **Instance Health Audit** skill (`/instance-audit`, lightdash/lightdash-cloud#2803) links to from each recommendation. Until now the audit's recommendations had no documented best-practice to back the "why". The audit's "Learn more" deep-links target the four H2 anchors on this page (`#adoption`, `#access-governance`, `#content-lifecycle`, `#cost-performance`), so those headings must not be reworded.

## Notes

- Page registered in `docs.json` nav under the guides group.
- Conceptual best-practice prose (not an auto-generated config/env reference), so hand-authored is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)