### PR TITLE
docs: simplify date_zoom usage description

### DIFF
--- a/guides/date-zoom.mdx
+++ b/guides/date-zoom.mdx
@@ -81,7 +81,7 @@ It resolves to the granularity name in lowercase (for example `day`, `week`, `mo
   <img src="/images/guides/date-zoom/date-zoom-reserved-parameter-dark.png" alt="Custom SQL editor autocomplete listing ${ld.parameters.date_zoom} as a System variable" className="hidden dark:block" />
 </Frame>
 
-This is useful for adapting SQL — labels, window sizes, formatting — to the granularity the viewer picked on the dashboard, without defining a user parameter:
+This is useful for adapting your SQL to the granularity the viewer picked on the dashboard, without defining a user parameter:
 
 ```sql
 CASE

--- a/guides/developer/using-parameters.mdx
+++ b/guides/developer/using-parameters.mdx
@@ -834,7 +834,7 @@ Reference it in custom SQL just like any other parameter:
 ${ld.parameters.date_zoom}
 ```
 
-This lets you branch SQL based on the dashboard's current granularity selection — for example, to swap label formatting, change a window size, or short-circuit logic when no granularity is selected:
+This lets you branch SQL based on the dashboard's current granularity selection, including falling back to default logic when no granularity is selected:
 
 ```sql
 CASE


### PR DESCRIPTION
Tightens the `date_zoom` reserved parameter docs added in #888.

The previous wording framed the main use case around adapting labels, window sizes, and formatting. In practice the primary use is changing the SQL based on the selected date zoom, so this drops the narrower examples and the em-dashes.

- `guides/date-zoom.mdx`: simplify the "useful for" sentence
- `guides/developer/using-parameters.mdx`: reword the branching description, with the no-granularity case as falling back to default logic