### PR TITLE
docs: custom email domain (white-labeled report emails)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -280,7 +280,8 @@
                   "references/workspace/scim-integration",
                   "references/workspace/sso-providers",
                   "references/workspace/configure-sso",
-                  "references/workspace/verified-domains"
+                  "references/workspace/verified-domains",
+                  "references/workspace/custom-email-domain"
                 ]
               },
               "references/workspace/feature-maturity-levels"

--- a/references/workspace/custom-email-domain.mdx
+++ b/references/workspace/custom-email-domain.mdx
@@ -1,0 +1,82 @@
+---
+title: "Custom email domain"
+description: "Send Lightdash report emails from your own domain (white-labeled email) instead of a Lightdash address."
+---
+
+<CardGroup cols={2}>
+  <Card title="Cloud Enterprise" icon="rocket" horizontal />
+</CardGroup>
+
+<Info>
+  Custom email domains are an Enterprise feature and are enabled per
+  organization. Contact the Lightdash team if you don't see the **Email
+  domain** panel in your organization settings.
+</Info>
+
+## What is a custom email domain?
+
+By default, scheduled deliveries and alerts are emailed from a Lightdash
+address. With a custom email domain, those emails send from an address on
+**your own domain** instead — for example `reports@yourcompany.com`.
+
+Emails are authenticated with DKIM and a custom return-path so they pass
+DMARC alignment for your domain. This is useful when you want to:
+
+- **Match your brand.** Report emails look like they come from your company,
+  not from Lightdash — especially important if you share dashboards with
+  clients or embed Lightdash in your own product.
+- **Improve deliverability.** Authenticated email from your own domain is
+  less likely to land in spam, and recipients are more likely to recognize
+  and open it.
+- **Keep replies.** Recipients who reply reach an address you own.
+
+## Set up your sending domain
+
+You must be an organization admin, and you'll need access to your domain's
+DNS settings.
+
+1. In your Lightdash instance, click your initials at the top right and
+   select **Organization settings**.
+2. Open the **Email domain** panel.
+3. Enter the domain you want to send from. We recommend a dedicated
+   subdomain like `reports.yourcompany.com` — it keeps your report email
+   reputation separate from your primary mail domain.
+4. Enter the **From address** (an address at that domain, e.g.
+   `reports@reports.yourcompany.com`) and an optional **From name**.
+5. Click **Set up domain**. Lightdash shows two DNS records to add at your
+   DNS provider: a **DKIM** TXT record and a **Return-Path** CNAME record.
+6. Add both records at your DNS provider, then click **Verify DNS records**.
+
+DNS changes can take anywhere from a few minutes to 24 hours to propagate.
+You can leave the page and come back — Lightdash re-checks pending domains
+in the background and emails your organization's admins once the domain
+verifies.
+
+<Warning>
+  **Using Cloudflare?** The Return-Path CNAME record must be set to **DNS
+  Only** (grey cloud), not proxied. A proxied record will never verify.
+</Warning>
+
+## Enable sending
+
+Both records must verify before you can enable sending. Once the domain
+shows as **Verified**, turn on **Send from this domain**. From then on,
+scheduled deliveries and alerts send from your address.
+
+Until your domain is verified and enabled, emails keep sending from the
+Lightdash address with your from-address set as the reply-to — setup never
+blocks or delays your scheduled deliveries.
+
+## Disable or remove
+
+- Turn off **Send from this domain** to revert to the Lightdash sending
+  identity. Your domain stays verified so you can re-enable it anytime.
+- Click **Remove domain** to delete the sending domain and its DNS
+  configuration entirely.
+
+## Related resources
+
+- [Scheduled deliveries](/guides/how-to-create-scheduled-deliveries)
+- [Alerts](/guides/how-to-create-alerts)
+- [Verified domains](/references/workspace/verified-domains) (separate
+  feature — proves domain ownership for SSO routing)


### PR DESCRIPTION
Adds a user-facing guide for the new **custom email domain** feature (Enterprise, cloud-only): send scheduled deliveries and alerts from the customer's own domain with DKIM + return-path (DMARC alignment).

- New page: `references/workspace/custom-email-domain.mdx` (why it's useful, setup walkthrough, Cloudflare DNS-Only warning, fallback behaviour, disable/remove)
- Added to the Admin nav group after Verified domains

Feature ships in lightdash/lightdash#25268 — hold merging until that's released.

Relates: PROD-8732