### PR TITLE
docs: correct AI writeback thread-to-PR model (multiple PRs per thread)

### DIFF
--- a/guides/ai-agents/ai-writeback.mdx
+++ b/guides/ai-agents/ai-writeback.mdx
@@ -163,15 +163,14 @@ If the preview can't be built — for example, the project isn't connected to Gi
 
 ## Iterating on an existing pull request
 
-If you've already opened a writeback pull request — either earlier in the same thread or by pasting a link to one — the agent commits follow-up changes onto that PR's branch instead of opening a new one. The PR's title and description are refreshed to reflect the latest change.
+When you follow up on a change whose pull request is already open — either earlier in the same thread or one you pasted a link to — the agent commits onto that PR's branch instead of opening a new one, and refreshes its title and description to reflect the latest change.
 
-There are two ways this happens:
-
-- **Same thread.** If the thread already has a writeback PR, any further writeback requests in that thread automatically resume it. You don't need to paste the link.
-- **Paste a link.** In a new thread (or before a writeback PR exists for the current thread), paste the GitHub pull request URL alongside your request. The agent picks up the link, checks out that PR's branch, and commits your edits onto it.
+- **Continue the current change.** A follow-up, fix, or refinement to a change you just asked for resumes its pull request automatically. You don't need to paste the link.
+- **Ask for a separate change.** When your next request is unrelated to the open PR, the agent opens a new pull request for it rather than piling an unrelated commit onto the existing one, and tells you what went into which PR.
+- **Paste a link.** Paste the GitHub pull request URL alongside your request — in this thread or a new one — and the agent checks out that PR's branch and commits your edits onto it.
 
 <Note>
-A thread is bound to its first writeback pull request. If that pull request is merged or closed — either from the chat card or directly on GitHub/GitLab — follow-up writeback requests in the same thread are blocked and the agent asks you to start a new thread. This prevents commits from being pushed to a dead branch.
+If the pull request behind a change has already been merged or closed — from the chat card or directly on GitHub/GitLab — the agent can't push more commits to its branch. Rather than blocking, it opens a fresh pull request for your follow-up in the same thread, so there's no need to start a new one.
 </Note>
 
 ```text
@@ -194,11 +193,10 @@ If any of those checks fail, the agent stops and tells you why instead of silent
 | Feature flag is off | The tool isn't available. The agent answers normally without offering to open a pull request. |
 | Project's dbt connection isn't GitHub or GitLab | The agent tells you the project must be connected to a supported git host for writeback. |
 | GitHub App isn't installed on the repo | The agent surfaces a setup error. Install the Lightdash GitHub App on the repository (from your project's dbt connection settings) and try again. |
-| Writeback agent makes no file changes | No pull request is opened. The agent reports back that nothing needed to change. |
-| Pasted PR link is in a different repo, merged, closed, or from a fork | The agent rejects the link with an explanation and does not open a new pull request. |
-| Thread's existing writeback PR has been merged or closed | Follow-up requests in that thread are blocked. Start a new thread to open a fresh pull request. |
-| GitLab App isn't connected for the organization | The agent surfaces a `GitLab App is not installed` error. Connect the Lightdash GitLab App for your organization and try again. |
 | Writeback agent makes no file changes | No pull request or merge request is opened. The agent reports back that nothing needed to change. |
+| Pasted PR link is in a different repo, merged, closed, or from a fork | The agent rejects the link with an explanation and does not open a new pull request. |
+| The pull request behind a change has been merged or closed | The agent can't add to that pull request, so a follow-up opens a fresh one in the same thread. |
+| GitLab App isn't connected for the organization | The agent surfaces a `GitLab App is not installed` error. Connect the Lightdash GitLab App for your organization and try again. |
 
 ## Related
 

--- a/guides/ai-agents/ai-writeback.mdx
+++ b/guides/ai-agents/ai-writeback.mdx
@@ -117,7 +117,7 @@ The writeback PR card has two action groups:
   - Both actions ask you to confirm before sending the request.
   - Once the PR reaches a terminal state, the button group collapses to a **Merged** or **Closed** marker and the card stops polling.
 
-After merging, refresh dbt in Lightdash (or let your CI/CD do it) so the change takes effect.
+When you merge from the card, Lightdash recompiles the project automatically — the same refresh as **Settings → Project → Sync dbt project** — so the merged change goes live without a manual sync. If the change renamed or removed a field, the agent then presents a plan to migrate the affected charts and dashboards to the new fields and, where it has edit access, repoints them for you once you confirm.
 
 <Note>
   Merging or closing a writeback PR from the card uses your project permissions
@@ -127,6 +127,14 @@ After merging, refresh dbt in Lightdash (or let your CI/CD do it) so the change 
   example, branch protection blocks it or the head moved), the error is
   surfaced on the card.
 </Note>
+
+## Impact and safety checks
+
+For changes that could break existing content or change results, the agent does extra work around the pull request so you can review it with confidence.
+
+**What the change would break.** When a change removes or renames a metric or dimension, saved charts, dashboards, dependent metrics, and scheduled deliveries may still reference the old field. After opening the pull request, the agent reports the impact in its reply — whether the change is breaking, how many items of each kind are affected, and a few of the most notable ones — or tells you it's safe when nothing references the field. This is advisory and never delays opening the PR; pure additions and description-only edits skip it.
+
+**That the numbers still hold.** When a change relies on results staying the same — consolidating two duplicate metrics, replacing one field with another, splitting a metric into parts, or refactoring a field's SQL — the agent proves it rather than asserting it. It either shows the guarantee from the model SQL, or runs the affected fields at a total and across a time dimension and confirms they match, before calling the change safe. If the numbers diverge, it tells you exactly what differs instead of shipping the change.
 
 ## Reading the dbt repository
 


### PR DESCRIPTION
## What

Brings the [AI writeback (Beta)](https://docs.lightdash.com/guides/ai-agents/ai-writeback) guide in line with how writeback works today. Two themes:

1. A chat thread now drives **several** pull requests, so the one-PR-per-thread language is gone.
2. Several current behaviours were undocumented (and one step was stale), so the guide now describes them.

## Changes

**Multiple PRs per thread**
- Reworked the **Iterating on an existing pull request** bullets: *continue the current change* resumes its PR, an *unrelated change* opens a new PR, pasting a link is unchanged.
- Corrected the merged/closed `<Note>`: the agent now opens a fresh PR in the same thread rather than blocking and asking you to start a new thread.
- Fixed the matching troubleshooting-table row and removed a duplicate "no file changes" row.

**Newly documented behaviour**
- **Impact analysis** — a new *Impact and safety checks* section: when a change removes or renames a field, the agent reports the affected charts, dashboards, dependent metrics, and scheduled deliveries when it opens the PR.
- **Value correctness** — the same section: for consolidations, replacements, splits, and SQL refactors the agent proves the numbers are preserved before calling a change safe.
- **Automatic post-merge recompile** — the old "after merging, refresh dbt" step was stale. Merging now recompiles the project automatically, and the agent offers to repoint any renamed/removed fields in affected content.

## Verification

Confirmed against the current `lightdash/lightdash` backend:
- `ai_writeback_thread` re-keyed per workstream (partial `UNIQUE(ai_thread_uuid, pull_request_uuid)`); `editDbtProject` supports `startNewPullRequest` / `prUrl` routing plus a `listWorkstreams` tool; the merged/closed error guides the agent to open a new PR in the same thread.
- `analyzeFieldImpact` reports charts / dashboards / dependent metrics / scheduled deliveries; `editContent` repoints content; the merge path (`mergePullRequest` → `scheduleCompileAfterMerge`) schedules the recompile and injects a hidden post-merge migration prompt.
- Value-correctness proof and the "recompile is automatic, don't offer to sync" rule are enforced in the writeback system prompt.
- Pasted-link constraints (same repo, open, no forks) are still enforced, so that part of the guide is unchanged.

Docs-only change — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)