### PR TITLE
docs: remove duplicated blocks from timezones guide

### DIFF
--- a/guides/developer/timezones.mdx
+++ b/guides/developer/timezones.mdx
@@ -15,15 +15,7 @@ This guide is in two parts:
   **tl;dr:** store timestamps as timezone-aware types, use `DATE` for calendar values, and set your [project timezone](#configure-your-project-timezone) to the zone you report in.
 </Info>
 
-# Timezone Setup
-
-<Info>
-  **tl;dr:** store timestamps as timezone-aware types, use `DATE` for calendar values, and set your [project timezone](#configure-your-project-timezone) to the zone you report in. 
-</Info>
-
 ## Timezone conversion
-
-Lightdash converts the timezones of your data from their **source timezone** to a **report timezone**: 
 
 Lightdash converts the timezones of your data from their **source timezone** to a **report timezone**:
 
@@ -80,19 +72,6 @@ In **Project settings** → **Timezone**, pick the zone you want reports to use.
 - Timestamps are displayed in tables, on chart axes, and in exports.
 - "Today" and "yesterday" are computed in relative date filters.
 - Data is bucketed in a per-day grouped bar chart.
-
-<Frame>
-  <img
-    alt="Project query timezone field in Project Settings"
-    className="block dark:hidden"
-    src="/images/guides/developer/timezones/project-query-timezone-setting-light.png"
-  />
-  <img
-    alt="Project query timezone field in Project Settings"
-    className="hidden dark:block"
-    src="/images/guides/developer/timezones/project-query-timezone-setting-dark.png"
-  />
-</Frame>
 
 <Frame>
   <img
@@ -214,12 +193,6 @@ If it's not the zone you expect, change it with the [timezone picker](#choosing-
 ## Report timezone resolution
 
 A chart's own timezone setting decides what zone it uses, unless an embed overrides it. The zone it ends up using is its **resolved timezone**, the term used throughout this guide. From highest priority:
-
-1. **A direct embed's** `timezone `**URL parameter** (on iframe or shareable-URL embeds only, see [Embedded dashboards](#embedded-dashboards)). This outranks everything.
-2. Otherwise, the chart's timezone setting applies:
-   - **Project timezone** (the default): the project's timezone, for every viewer.
-   - **User timezone**: the viewer's profile timezone, or the project timezone if they haven't set one.
-   - **A specific timezone**: that exact zone, the same for everyone.
 
 1. **A direct embed's** `timezone `**URL parameter** (on iframe or shareable-URL embeds only, see [Embedded dashboards](#embedded-dashboards)). This outranks everything.
 2. Otherwise, the chart's timezone setting applies:


### PR DESCRIPTION
Removes four blocks that were accidentally duplicated in the timezones guide by a Mintlify dashboard-editor save (6b22d18):

- The `# Timezone Setup` heading and its tl;dr callout
- The "Lightdash converts the timezones..." intro sentence
- The project timezone settings screenshot
- The timezone resolution priority list

No content changes, only duplicate removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)