### PR TITLE
docs: Google Cloud Run Sandboxes provider setup for self-hosted

### DIFF
--- a/self-host/customize-deployment/sandboxes.mdx
+++ b/self-host/customize-deployment/sandboxes.mdx
@@ -43,10 +43,9 @@ the provider with the `SANDBOX_PROVIDER` environment variable.
 | **Local Docker** | `docker` | Local development only | container |
 
 **E2B**, **AWS Lambda MicroVMs**, and **Azure Container Apps Sandboxes** are all supported
-production backends. E2B is the managed default; the AWS, Azure, and Google Cloud providers
-are for teams who want sandboxes to run inside their own cloud account. The Google Cloud
-provider builds on Cloud Run Sandboxes, which is a Google Cloud **public preview** feature.
-More providers (Kubernetes, ECS) are planned.
+production backends. E2B is the managed default; the AWS and Azure providers are for teams
+who want sandboxes to run inside their own cloud account. More providers (Kubernetes, ECS)
+are planned.
 
 <Warning>
 The **local Docker provider is for development only**. It launches plain Docker containers
@@ -223,124 +222,121 @@ to non-allowlisted hosts are rejected, and all other ports are blocked.
 
 ## Google Cloud Run Sandboxes (self-hosted, preview)
 
-[Cloud Run Sandboxes](https://docs.cloud.google.com/run/docs/code-execution) run each
-sandbox as a gVisor-isolated execution environment **inside a Cloud Run service in your
-own Google Cloud project**, so untrusted agent code never leaves your infrastructure.
-Sandboxes start in milliseconds and cost nothing extra — they share the CPU and memory
-already allocated to the Cloud Run service that hosts them.
-
-The architecture differs from the AWS and Azure providers: sandboxes are spawned *inside*
-a Cloud Run service deployed with `--sandbox-launcher`. You deploy one small **gateway
-service** whose container image bundles the data-app toolchain plus a thin HTTP gateway;
-each sandbox sees that image's filesystem read-only with a writable overlay, and your
-Lightdash backend drives sandboxes remotely through the gateway's HTTP API.
+Use the `gcp-cloud-run` provider to run data app sandboxes in a
+[Cloud Run service](https://docs.cloud.google.com/run/docs/code-execution). Lightdash
+connects to the service through an HTTP gateway included in the sandbox image.
 
 <Note>
-Cloud Run Sandboxes is a Google Cloud **public preview** feature, and this provider
-currently supports **data app generation only** — AI writeback is not yet available on
-`gcp-cloud-run` (it needs a second gateway with the writeback toolchain). Selecting this
-provider with writeback enabled fails with a clear configuration error at use time.
+Cloud Run Sandboxes is in public preview and currently supports data app generation only.
+AI writeback is not supported.
 </Note>
 
 ### Prerequisites
 
-- A Google Cloud project with billing, and the `gcloud` CLI (recent enough to have
-  `gcloud beta run deploy --sandbox-launcher` — update with `gcloud components update`).
-- The **Cloud Run** and **Cloud Build** APIs enabled:
-  `gcloud services enable run.googleapis.com cloudbuild.googleapis.com`
-- **S3-compatible object storage** configured for Lightdash. Like the Docker provider,
-  `gcp-cloud-run` persists suspended-sandbox snapshots as tarballs in object storage so a
-  conversation survives the sandbox being destroyed — see
-  [external object storage](/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage).
-- An Anthropic API key (`ANTHROPIC_API_KEY`) for the agent.
+- A Google Cloud project with billing enabled.
+- A recent version of the `gcloud` CLI that supports
+  `gcloud beta run deploy --sandbox-launcher`.
+- A checkout of the Lightdash repository.
+- [External object storage](/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage)
+  configured for Lightdash.
+- An Anthropic API key.
 
-### Deploy the gateway service
+### 1. Enable the Google Cloud APIs
 
-1. Build the gateway image with Cloud Build. It's the Lightdash data-app sandbox image
-   with the [ComputeSDK Cloud Run gateway](https://github.com/computesdk/computesdk/tree/main/packages/cloud-run)
-   server on top. From a checkout of the Lightdash repo:
+```bash
+gcloud services enable run.googleapis.com cloudbuild.googleapis.com \
+  --project <your-project>
+```
 
-   ```bash
-   cd sandboxes/data-apps
+### 2. Build the gateway image
 
-   # Stage a build context: toolchain Dockerfile + the gateway server
-   STAGE=$(mktemp -d)
-   cp -R template lightdash-query-sdk.tgz "$STAGE/"
-   npm pack @computesdk/cloud-run --pack-destination "$STAGE" >/dev/null
-   tar -xzf "$STAGE"/computesdk-cloud-run-*.tgz -C "$STAGE" package/dist/gateway.mjs
-   mv "$STAGE/package/dist/gateway.mjs" "$STAGE/gateway.mjs"
+From the root of the Lightdash repository, run:
 
-   sed 's|^RUN chown -R user:user /app|RUN useradd -m -s /bin/bash user 2>/dev/null \|\| true|' \
-       e2b.Dockerfile > "$STAGE/Dockerfile"
-   cat >> "$STAGE/Dockerfile" <<'EOF'
+```bash
+cd sandboxes/data-apps
 
-   # ComputeSDK Cloud Run sandbox gateway. /app stays root-owned: sandboxes exec as
-   # root under gVisor, where non-root-owned files are inaccessible even to root.
-   COPY gateway.mjs /gateway/gateway.mjs
-   ENV NODE_ENV=production
-   CMD ["node", "/gateway/gateway.mjs"]
-   EOF
+STAGE=$(mktemp -d)
+cp -R template lightdash-query-sdk.tgz "$STAGE/"
+npm pack @computesdk/cloud-run --pack-destination "$STAGE" >/dev/null
+tar -xzf "$STAGE"/computesdk-cloud-run-*.tgz \
+  -C "$STAGE" package/dist/gateway.mjs
+mv "$STAGE/package/dist/gateway.mjs" "$STAGE/gateway.mjs"
 
-   gcloud builds submit "$STAGE" \
-     --tag gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
-     --project <your-project>
-   ```
+sed 's|^RUN chown -R user:user /app|RUN useradd -m -s /bin/bash user 2>/dev/null \|\| true|' \
+  e2b.Dockerfile > "$STAGE/Dockerfile"
 
-2. Deploy it as a Cloud Run service with the sandbox launcher enabled:
+cat >> "$STAGE/Dockerfile" <<'EOF'
 
-   ```bash
-   SANDBOX_SECRET=$(openssl rand -hex 32)
+COPY gateway.mjs /gateway/gateway.mjs
+ENV NODE_ENV=production
+CMD ["node", "/gateway/gateway.mjs"]
+EOF
 
-   gcloud beta run deploy lightdash-sandbox-gateway \
-     --image gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
-     --region <region> --project <your-project> \
-     --sandbox-launcher --no-cpu-throttling --session-affinity \
-     --cpu 4 --memory 16Gi --concurrency 20 \
-     --min-instances 1 --max-instances 1 \
-     --timeout 3600 \
-     --allow-unauthenticated \
-     --set-env-vars "SANDBOX_SECRET=$SANDBOX_SECRET"
-   ```
+gcloud builds submit "$STAGE" \
+  --tag gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
+  --project <your-project>
+```
 
-   The service is reachable publicly but every sandbox operation requires the shared
-   secret, which only your Lightdash backend holds. If your organization policy forbids
-   `--allow-unauthenticated`, grant your backend's service account `roles/run.invoker`
-   instead and front the call with an identity token.
+### 3. Deploy the gateway
 
-<Warning>
-Keep **`--min-instances 1 --max-instances 1`**. Sandboxes live inside a specific gateway
-instance while a generation is running, so instance churn mid-run kills the active
-sandbox. Suspended snapshots live in your object storage (not on the instance), so
-completed conversations survive redeploys — but budget for one always-on instance while
-the provider is in use. Because sandboxes share the gateway's resources, size the
-instance generously (4 CPU / 16 GiB works well).
-</Warning>
+Generate a shared secret and deploy the image:
 
-Updating the sandbox toolchain means rebuilding the image and redeploying the service —
-the image is fixed per deployment, so per-sandbox image selection is not available on
-this provider.
+```bash
+SANDBOX_SECRET=$(openssl rand -hex 32)
 
-### Configure the provider
+gcloud beta run deploy lightdash-sandbox-gateway \
+  --image gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
+  --region <region> \
+  --project <your-project> \
+  --sandbox-launcher \
+  --no-cpu-throttling \
+  --session-affinity \
+  --cpu 4 \
+  --memory 16Gi \
+  --concurrency 20 \
+  --min-instances 1 \
+  --max-instances 1 \
+  --timeout 3600 \
+  --allow-unauthenticated \
+  --set-env-vars "SANDBOX_SECRET=$SANDBOX_SECRET"
+```
+
+Save `SANDBOX_SECRET` securely. You need the same value when configuring Lightdash.
+Although the Cloud Run service allows unauthenticated requests, the gateway requires this
+secret for every sandbox operation.
+
+Keep the service at one instance. Active sandboxes run inside that instance and are lost
+if Cloud Run replaces it during a generation.
+
+### 4. Configure Lightdash
+
+Get the gateway URL:
+
+```bash
+gcloud run services describe lightdash-sandbox-gateway \
+  --region <region> \
+  --project <your-project> \
+  --format='value(status.url)'
+```
+
+Set these environment variables on both the Lightdash backend and scheduler:
 
 ```bash
 SANDBOX_PROVIDER=gcp-cloud-run
-ANTHROPIC_API_KEY=sk-ant-...   # the agent (Claude Code) runs inside the sandbox
-
-# The gateway service URL and the SANDBOX_SECRET you deployed it with. Required.
-GCP_CLOUD_RUN_SANDBOX_URL=https://lightdash-sandbox-gateway-<project-number>.<region>.run.app
+ANTHROPIC_API_KEY=sk-ant-...
+GCP_CLOUD_RUN_SANDBOX_URL=<gateway-url>
 GCP_CLOUD_RUN_SANDBOX_SECRET=<sandbox-secret>
 ```
 
-Restart the backend and the scheduler so both pick up the new environment.
+Restart the backend and scheduler to apply the configuration.
 
 <Warning>
-**Egress is all-or-nothing on this provider.** Cloud Run sandboxes support only a binary
-egress switch per sandbox (deny everything, or allow everything), so when a feature needs
-any outbound access (the Anthropic API), the sandbox launches with full egress and a
-warning is logged. There is no per-host allowlist like the Azure provider enforces —
-consider this when evaluating the provider for your threat model while the feature is in
-preview.
+Cloud Run sandboxes use unrestricted outbound network access when data app generation
+requires internet access. Per-host egress rules are not supported.
 </Warning>
+
+To update the sandbox toolchain, rebuild the gateway image and redeploy the Cloud Run
+service.
 
 ## Local Docker provider (development)
 

--- a/self-host/customize-deployment/sandboxes.mdx
+++ b/self-host/customize-deployment/sandboxes.mdx
@@ -39,12 +39,14 @@ the provider with the `SANDBOX_PROVIDER` environment variable.
 | **E2B** (default) | `e2b` | Production / managed | microVM |
 | **AWS Lambda MicroVMs** | `lambda-microvm` | Production on AWS (self-hosted) | microVM |
 | **Azure Container Apps Sandboxes** | `azure-sandboxes` | Production on Azure (self-hosted) | microVM |
+| **Google Cloud Run Sandboxes** | `gcp-cloud-run` | GCP (self-hosted, preview) | gVisor |
 | **Local Docker** | `docker` | Local development only | container |
 
 **E2B**, **AWS Lambda MicroVMs**, and **Azure Container Apps Sandboxes** are all supported
-production backends. E2B is the managed default; the AWS and Azure providers are for teams
-who want sandboxes to run inside their own cloud account. More providers (Kubernetes, ECS)
-are planned.
+production backends. E2B is the managed default; the AWS, Azure, and Google Cloud providers
+are for teams who want sandboxes to run inside their own cloud account. The Google Cloud
+provider builds on Cloud Run Sandboxes, which is a Google Cloud **public preview** feature.
+More providers (Kubernetes, ECS) are planned.
 
 <Warning>
 The **local Docker provider is for development only**. It launches plain Docker containers
@@ -219,6 +221,127 @@ with **full traffic inspection** so the platform enforces the deny on all traffi
 non-HTTP egress. Untrusted agent code can't reach any other destination — outbound requests
 to non-allowlisted hosts are rejected, and all other ports are blocked.
 
+## Google Cloud Run Sandboxes (self-hosted, preview)
+
+[Cloud Run Sandboxes](https://docs.cloud.google.com/run/docs/code-execution) run each
+sandbox as a gVisor-isolated execution environment **inside a Cloud Run service in your
+own Google Cloud project**, so untrusted agent code never leaves your infrastructure.
+Sandboxes start in milliseconds and cost nothing extra — they share the CPU and memory
+already allocated to the Cloud Run service that hosts them.
+
+The architecture differs from the AWS and Azure providers: sandboxes are spawned *inside*
+a Cloud Run service deployed with `--sandbox-launcher`. You deploy one small **gateway
+service** whose container image bundles the data-app toolchain plus a thin HTTP gateway;
+each sandbox sees that image's filesystem read-only with a writable overlay, and your
+Lightdash backend drives sandboxes remotely through the gateway's HTTP API.
+
+<Note>
+Cloud Run Sandboxes is a Google Cloud **public preview** feature, and this provider
+currently supports **data app generation only** — AI writeback is not yet available on
+`gcp-cloud-run` (it needs a second gateway with the writeback toolchain). Selecting this
+provider with writeback enabled fails with a clear configuration error at use time.
+</Note>
+
+### Prerequisites
+
+- A Google Cloud project with billing, and the `gcloud` CLI (recent enough to have
+  `gcloud beta run deploy --sandbox-launcher` — update with `gcloud components update`).
+- The **Cloud Run** and **Cloud Build** APIs enabled:
+  `gcloud services enable run.googleapis.com cloudbuild.googleapis.com`
+- **S3-compatible object storage** configured for Lightdash. Like the Docker provider,
+  `gcp-cloud-run` persists suspended-sandbox snapshots as tarballs in object storage so a
+  conversation survives the sandbox being destroyed — see
+  [external object storage](/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage).
+- An Anthropic API key (`ANTHROPIC_API_KEY`) for the agent.
+
+### Deploy the gateway service
+
+1. Build the gateway image with Cloud Build. It's the Lightdash data-app sandbox image
+   with the [ComputeSDK Cloud Run gateway](https://github.com/computesdk/computesdk/tree/main/packages/cloud-run)
+   server on top. From a checkout of the Lightdash repo:
+
+   ```bash
+   cd sandboxes/data-apps
+
+   # Stage a build context: toolchain Dockerfile + the gateway server
+   STAGE=$(mktemp -d)
+   cp -R template lightdash-query-sdk.tgz "$STAGE/"
+   npm pack @computesdk/cloud-run --pack-destination "$STAGE" >/dev/null
+   tar -xzf "$STAGE"/computesdk-cloud-run-*.tgz -C "$STAGE" package/dist/gateway.mjs
+   mv "$STAGE/package/dist/gateway.mjs" "$STAGE/gateway.mjs"
+
+   sed 's|^RUN chown -R user:user /app|RUN useradd -m -s /bin/bash user 2>/dev/null \|\| true|' \
+       e2b.Dockerfile > "$STAGE/Dockerfile"
+   cat >> "$STAGE/Dockerfile" <<'EOF'
+
+   # ComputeSDK Cloud Run sandbox gateway. /app stays root-owned: sandboxes exec as
+   # root under gVisor, where non-root-owned files are inaccessible even to root.
+   COPY gateway.mjs /gateway/gateway.mjs
+   ENV NODE_ENV=production
+   CMD ["node", "/gateway/gateway.mjs"]
+   EOF
+
+   gcloud builds submit "$STAGE" \
+     --tag gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
+     --project <your-project>
+   ```
+
+2. Deploy it as a Cloud Run service with the sandbox launcher enabled:
+
+   ```bash
+   SANDBOX_SECRET=$(openssl rand -hex 32)
+
+   gcloud beta run deploy lightdash-sandbox-gateway \
+     --image gcr.io/<your-project>/lightdash-sandbox-gateway:latest \
+     --region <region> --project <your-project> \
+     --sandbox-launcher --no-cpu-throttling --session-affinity \
+     --cpu 4 --memory 16Gi --concurrency 20 \
+     --min-instances 1 --max-instances 1 \
+     --timeout 3600 \
+     --allow-unauthenticated \
+     --set-env-vars "SANDBOX_SECRET=$SANDBOX_SECRET"
+   ```
+
+   The service is reachable publicly but every sandbox operation requires the shared
+   secret, which only your Lightdash backend holds. If your organization policy forbids
+   `--allow-unauthenticated`, grant your backend's service account `roles/run.invoker`
+   instead and front the call with an identity token.
+
+<Warning>
+Keep **`--min-instances 1 --max-instances 1`**. Sandboxes live inside a specific gateway
+instance while a generation is running, so instance churn mid-run kills the active
+sandbox. Suspended snapshots live in your object storage (not on the instance), so
+completed conversations survive redeploys — but budget for one always-on instance while
+the provider is in use. Because sandboxes share the gateway's resources, size the
+instance generously (4 CPU / 16 GiB works well).
+</Warning>
+
+Updating the sandbox toolchain means rebuilding the image and redeploying the service —
+the image is fixed per deployment, so per-sandbox image selection is not available on
+this provider.
+
+### Configure the provider
+
+```bash
+SANDBOX_PROVIDER=gcp-cloud-run
+ANTHROPIC_API_KEY=sk-ant-...   # the agent (Claude Code) runs inside the sandbox
+
+# The gateway service URL and the SANDBOX_SECRET you deployed it with. Required.
+GCP_CLOUD_RUN_SANDBOX_URL=https://lightdash-sandbox-gateway-<project-number>.<region>.run.app
+GCP_CLOUD_RUN_SANDBOX_SECRET=<sandbox-secret>
+```
+
+Restart the backend and the scheduler so both pick up the new environment.
+
+<Warning>
+**Egress is all-or-nothing on this provider.** Cloud Run sandboxes support only a binary
+egress switch per sandbox (deny everything, or allow everything), so when a feature needs
+any outbound access (the Anthropic API), the sandbox launches with full egress and a
+warning is logged. There is no per-host allowlist like the Azure provider enforces —
+consider this when evaluating the provider for your threat model while the feature is in
+preview.
+</Warning>
+
 ## Local Docker provider (development)
 
 For local development you can run sandboxes as plain Docker containers on your own machine
@@ -282,13 +405,15 @@ SANDBOX_SNAPSHOT_RETENTION_MS=604800000 # auto-terminate a suspended microVM (de
 **Azure Sandboxes** providers (for Azure it sets each sandbox's Memory-mode auto-suspend
 interval). `SANDBOX_SNAPSHOT_RETENTION_MS` is read only by Lambda MicroVMs — on Azure,
 suspended-sandbox retention is governed by the sandbox group's own auto-delete policy.
-**E2B** manages idle sandboxes itself, and the **Docker** dev provider has no idle handling.
+**E2B** manages idle sandboxes itself, and the **Docker** and **Cloud Run** providers have
+no cloud-side idle handling — both persist suspend-time snapshots to object storage and
+destroy the sandbox, so nothing idles in the first place.
 
 ## Environment variable reference
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SANDBOX_PROVIDER` | `e2b` | Sandbox backend: `e2b`, `lambda-microvm`, `azure-sandboxes`, or `docker`. |
+| `SANDBOX_PROVIDER` | `e2b` | Sandbox backend: `e2b`, `lambda-microvm`, `azure-sandboxes`, `gcp-cloud-run`, or `docker`. |
 | `ANTHROPIC_API_KEY` | — | API key for the Claude Code agent running inside the sandbox. |
 | `E2B_API_KEY` | — | E2B API key (required when `SANDBOX_PROVIDER=e2b`). |
 | `E2B_TEMPLATE_NAME` | `lightdash/lightdash-data-app` | E2B template for data app sandboxes. |
@@ -311,6 +436,8 @@ suspended-sandbox retention is governed by the sandbox group's own auto-delete p
 | `AZURE_SANDBOXES_RESOURCE_TIER` | `M` | Sandbox size: `XS`, `S`, `M`, or `L`. |
 | `AZURE_SANDBOXES_API_VERSION` | `2026-02-01-preview` | Azure Sandboxes data-plane API version. |
 | `AZURE_SANDBOXES_TOKEN_SCOPE` | `https://management.azuredevcompute.io/.default` | Entra token scope for the data plane. |
+| `GCP_CLOUD_RUN_SANDBOX_URL` | — | URL of the sandbox gateway Cloud Run service (required when `SANDBOX_PROVIDER=gcp-cloud-run`). |
+| `GCP_CLOUD_RUN_SANDBOX_SECRET` | — | Shared secret the gateway was deployed with (required when `gcp-cloud-run`). |
 | `SANDBOX_DOCKER_IMAGE` | `lightdash-sandbox:local` | Local image for data app sandboxes (`docker` provider). |
 | `SANDBOX_AI_WRITEBACK_DOCKER_IMAGE` | `lightdash-ai-writeback:local` | Local image for writeback sandboxes (`docker` provider). |
 | `SANDBOX_IDLE_TIMEOUT_MS` | `1800000` (30 min) | Auto-suspend a running-but-idle sandbox (`lambda-microvm` and `azure-sandboxes`). Ignored by `e2b`/`docker`. |


### PR DESCRIPTION
## Summary

Documents the new `gcp-cloud-run` sandbox provider on the self-hosted **Sandboxes** page so self-hosted customers can self-serve the setup:

- Adds Google Cloud Run Sandboxes to the provider table (gVisor isolation, GCP public preview).
- New section covering the gateway architecture (one Cloud Run service deployed with `--sandbox-launcher`, toolchain baked into the gateway image), prerequisites, a copy-pastable Cloud Build + deploy recipe, backend configuration (`GCP_CLOUD_RUN_SANDBOX_URL` / `GCP_CLOUD_RUN_SANDBOX_SECRET`), and the preview caveats (data apps only, all-or-nothing egress, min-instances sizing).
- Updates the snapshot lifecycle notes and the environment variable reference.

Pairs with the backend provider PR: https://github.com/lightdash/lightdash/pull/25976 — this page should merge once that ships in a release.

Relates: PROD-8590