### PR TITLE
docs: fix dead Google link on SCIM integration page

### DIFF
--- a/references/workspace/scim-integration.mdx
+++ b/references/workspace/scim-integration.mdx
@@ -354,7 +354,7 @@ The SCIM roles model is currently an [IETF draft](https://datatracker.ietf.org/d
 
 - Okta: Does not natively auto-populate role picklists by consuming a SCIM `/Roles` endpoint. You can still provision `roles` [manually](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-add-custom-user-attributes.htm) or implement custom sync using [Okta Workflows](https://help.okta.com/wf/en-us/content/topics/workflows/workflows-main.htm) or a [custom app](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard.htm).
 - Microsoft Entra ID (Azure AD): Does not currently auto-discover roles from `/Roles`. Use [manual configuration](https://learn.microsoft.com/azure/active-directory/app-provisioning/customize-application-attributes) of allowed roles.
-- Google Cloud Identity / Workspace: No native auto-consumption of `/Roles`. Use [manual configuration](https://support.google.com/cloudidentity/answer/6208725) of allowed roles.
+- Google Cloud Identity / Workspace: No native auto-consumption of `/Roles`. Use [manual configuration](https://knowledge.workspace.google.com/admin/users/advanced/about-automated-user-provisioning) of allowed roles.
 - SailPoint (IdentityNow/IdentityIQ): Supports SCIM roles harvesting; with the right connector configuration, it can ingest roles from custom endpoints like `/Roles`.
 - Other IGA/IM tools (e.g., OneLogin): Some support importing roles from SCIM apps; use depends on the specific connector.
 


### PR DESCRIPTION
## Summary
The Google "manual configuration" link in the SCIM roles section (`references/workspace/scim-integration.mdx`) is dead — `support.google.com/cloudidentity/answer/6208725` now 301-redirects to a generic Cloud Identity docs index because Google migrated its Workspace admin help to `knowledge.workspace.google.com`.

Replaced it with the live [About automated user provisioning](https://knowledge.workspace.google.com/admin/users/advanced/about-automated-user-provisioning) article (verified live, last updated July 2026).

Reported by Employment Hero in [Slack](https://lightdash.slack.com/archives/C03MCQ08UKS/p1784780945671979).

Follow-up with a full Google Workspace guide: #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)