### PR TITLE
docs: document CLI compilation flags

### DIFF
--- a/guides/cli/how-to-use-lightdash-deploy.mdx
+++ b/guides/cli/how-to-use-lightdash-deploy.mdx
@@ -60,6 +60,22 @@ Be careful. If your local prod profile isn't properly pointing to your productio
 this can result in incorrect connections (e.g. accidentally deploying to a dev dataset).
 </Warning>
 
+### Use strict compilation
+
+`lightdash deploy` uses partial compilation by default. Field, join, and set-validation failures that can be isolated do not block the rest of the explore from being deployed; failures that cannot be isolated can still stop the deployment. Add `--no-partial-compilation` when failures normally handled by partial compilation should stop the deployment:
+
+```bash
+lightdash deploy --no-partial-compilation
+```
+
+For projects that use physical references such as `${TABLE}.order_id`, add `--validate-warehouse-columns` to check supported unquoted columns with warehouse queries that return no rows before deploying:
+
+```bash
+lightdash deploy --no-partial-compilation --validate-warehouse-columns
+```
+
+Other generic compilation warnings remain non-blocking. Do not combine `--ignore-errors` with this strict CI pattern: `--ignore-errors` allows a deployment to continue after compilation errors. See the [CLI compilation options](/references/lightdash-cli#partial-compilation) for details.
+
 ## Option 2: Safely refresh metadata using `lightdash refresh`
 
 If you only need to refresh your Lightdash project to reflect upstream dbt changes (like updated models or docs), but don’t want to deploy your local dbt setup, you can use:

--- a/guides/cli/how-to-use-lightdash-preview.mdx
+++ b/guides/cli/how-to-use-lightdash-preview.mdx
@@ -20,6 +20,20 @@ or
 lightdash start-preview
 ```
 
+Both commands use partial compilation by default. Field, join, and set-validation failures that can be isolated are reported as warnings while the rest of the explore remains available; failures that cannot be isolated can still fail the preview. Add `--no-partial-compilation` when failures normally handled by partial compilation should fail the preview instead:
+
+```bash
+lightdash start-preview --name "strict-preview" --no-partial-compilation
+```
+
+To also verify supported unquoted `${TABLE}.column` references with warehouse queries that return no rows, add `--validate-warehouse-columns`:
+
+```bash
+lightdash start-preview --name "strict-preview" --no-partial-compilation --validate-warehouse-columns
+```
+
+These flags work with both `lightdash preview` and `lightdash start-preview`. Other generic compilation warnings remain non-blocking, and `--ignore-errors` allows preview creation to continue after strict compilation errors. See the [CLI compilation options](/references/lightdash-cli#partial-compilation) for details.
+
 Then `cmd` + `click` to open the preview link from your terminal. Once you're in Lightdash go to `Explore` --> `Tables`, then click on the model(s) you just updated to see your changes and play around with them.
 
 <Tip>

--- a/guides/cli/how-to-use-lightdash-validate.mdx
+++ b/guides/cli/how-to-use-lightdash-validate.mdx
@@ -53,6 +53,38 @@ Available options:
 
 * `dashboards`
 
+### Use strict compilation during validation
+
+`lightdash validate` uses partial compilation by default. Field, join, and set-validation failures that can be isolated are reported as warnings so Lightdash can continue validating the rest of the explore; failures that cannot be isolated can still produce model errors.
+
+Use `--no-partial-compilation` to report failures normally handled by partial compilation as model errors:
+
+```bash
+lightdash validate --no-partial-compilation
+```
+
+Tables are included in validation by default, so model errors for tables enabled by your project's table configuration make the command exit with an error. If you use `--only` and exclude `tables`, the compile output can still show `ERROR`, but only the selected validation targets determine the final exit status. Other generic compilation warnings remain non-blocking.
+
+This replaces the removed `PARTIAL_COMPILATION_ENABLED=false` environment-variable behavior.
+
+### Validate physical column references against the warehouse
+
+Use `--validate-warehouse-columns` to check supported unquoted `${TABLE}.column` references with warehouse queries that return no rows:
+
+```bash
+lightdash validate --validate-warehouse-columns
+```
+
+Warehouse-column errors remain errors whether partial compilation is enabled or disabled. You can combine both flags for the strictest check:
+
+```bash
+lightdash validate --validate-warehouse-columns --no-partial-compilation
+```
+
+`lightdash validate` includes tables by default, so no additional option is required. If you customize `--only`, keep `tables` in the list to run the warehouse check; use `--only tables` when you want to validate tables without charts or dashboards.
+
+The check requires warehouse credentials and the warehouse catalog, and is skipped for dbt Cloud CLI and Lightdash YAML-only compilation. See the [CLI reference](/references/lightdash-cli#validate-physical-warehouse-columns) for supported reference syntax and all skip conditions.
+
 ## Configure Github actions
 
 This command will create a preview environment, and then validate this preview by specifying `--preview` on the validate command.`lightdash validate` will return an error (return code 1) if there is at least 1 validation error on your project. You can use this output to block a deploy on Github actions like this

--- a/guides/developer/cli/how-to-compile-your-lightdash-project.mdx
+++ b/guides/developer/cli/how-to-compile-your-lightdash-project.mdx
@@ -6,6 +6,30 @@ description: If you've connected Lightdash to GitHub, you can setup a `github ac
 
 Adding this Lightdash compile action will compile your dbt project's .yml files and check to see if there are any errors that will break your Lightdash project. For example, a metric that references a dimension that doesn't exist.
 
+## Choose partial or strict compilation
+
+By default, `lightdash compile` uses partial compilation. If a field, join, or set-validation failure can be isolated, Lightdash reports a warning and the explore as `PARTIAL_SUCCESS`, then exits successfully so the rest of the explore remains usable. Failures that cannot be isolated can still produce `ERROR`.
+
+For a CI check that reports failures normally handled by partial compilation as errors, use strict compilation:
+
+```bash
+lightdash compile --no-partial-compilation
+```
+
+Other generic compilation warnings remain non-blocking.
+
+If your project uses physical column references such as `${TABLE}.order_id`, you can also verify supported unquoted references against the warehouse:
+
+```bash
+lightdash compile --no-partial-compilation --validate-warehouse-columns
+```
+
+`--validate-warehouse-columns` is opt-in because it sends validation queries that return no rows. Warehouse scanning and billing behavior still depends on your warehouse. The flag requires warehouse credentials and the warehouse catalog. See [partial compilation and physical warehouse-column validation](/references/lightdash-cli#partial-compilation) for supported syntax and skip conditions.
+
+<Note>
+  `PARTIAL_COMPILATION_ENABLED=false` is no longer supported. Replace it in CI configuration with `--no-partial-compilation` on the `lightdash compile` command.
+</Note>
+
 ### Step 1: add the credentials to Github secrets
 
 We are going to add some secrets and config to GitHub actions, but you don't want those to be public, so the best way to do this is to add them as secrets on Github.

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -273,6 +273,30 @@ Compile Lightdash resources using your local project and database credentials. d
 
 All standard [dbt options](#dbt-options) work with `lightdash compile`.
 
+#### Partial compilation
+
+Lightdash uses partial compilation by default. If an individual field, join, or set-validation failure can be isolated, Lightdash records a warning, keeps the rest of the explore available, and prints the explore as `PARTIAL_SUCCESS`. Failures that cannot be isolated can still produce `ERROR`.
+
+Use `--no-partial-compilation` when failures normally handled by partial compilation must be reported as errors instead. The flag does not promote unrelated, non-blocking warnings to errors. The strict compilation summary omits those remaining generic warnings, although deploy and preview commands can print them in the post-upload warning report. Warehouse-column errors remain blocking in both modes.
+
+The flag is available on `lightdash compile`, `lightdash validate`, `lightdash deploy`, `lightdash preview`, and `lightdash start-preview`. `--ignore-errors` still allows deploy and preview commands to continue after strict compilation errors.
+
+<Note>
+  The `PARTIAL_COMPILATION_ENABLED` environment variable is no longer supported and no longer controls server or CLI behavior. Project create, update, and refresh paths use partial compilation, and CLI compilation uses it by default. Use `--no-partial-compilation` on a supported CLI command when you need strict field and join compilation for that run.
+</Note>
+
+#### Validate physical warehouse columns
+
+Semantic compilation can verify Lightdash field references, but it does not normally execute physical `${TABLE}.column` references against your warehouse. Add `--validate-warehouse-columns` to run `SELECT … WHERE 1 = 0` probes that return no rows. Whether a warehouse scans or bills for data is warehouse-dependent.
+
+The scanner examines dimension and metric SQL in successfully compiled explores. It recognizes unquoted references containing letters, numbers, or underscores, such as `${TABLE}.order_id`. Quoted references such as `${TABLE}."order id"` are not checked, and tables whose relation contains a `${...}` template are skipped.
+
+A column rejected by the warehouse is reported as an error in both partial and strict compilation modes. After a batched probe fails, the CLI runs a zero-row relation-control probe. If a control probe fails for any reason, the CLI reports no column error because it cannot isolate a column-specific failure. An individual failed column probe is reported only when its follow-up control probe succeeds.
+
+This validation requires a warehouse client and the warehouse catalog. `--skip-warehouse-catalog` disables it. The check is also skipped when no tables are selected, when compilation uses dbt Cloud CLI or a Lightdash YAML-only project, or when `lightdash deploy` automatically skips the warehouse catalog for a Spark target.
+
+The flag is available on the same five compilation commands. `lightdash validate` includes tables by default, so the check runs without `--only`. If you customize `--only`, keep `tables` in the list to run the warehouse check.
+
 **Options:**
 
 - `--skip-dbt-compile`
@@ -284,6 +308,11 @@ All standard [dbt options](#dbt-options) work with `lightdash compile`.
 - `--no-warehouse-credentials`
   - (default: false)
   - Compile without any warehouse credentials. Skips dbt compile + warehouse catalog
+- `--validate-warehouse-columns`
+  - (default: false)
+  - Validate supported physical `${TABLE}.column` references against the warehouse
+- `--no-partial-compilation`
+  - Report failures normally handled by partial compilation as errors
 - `--disable-timestamp-conversion [true|false]`
   - (default: false)
   - Snowflake only. Disable converting timestamps to UTC during compilation. Only use this if your timestamp values are already in UTC.
@@ -333,6 +362,11 @@ All standard [dbt options](#dbt-options) work with `lightdash preview`.
 - `--use-dbt-list [true/false]`
   - (default: true)
   - Use `dbt list` instead of `dbt compile` to generate dbt manifest.json
+- `--validate-warehouse-columns`
+  - (default: false)
+  - Validate supported physical `${TABLE}.column` references against the warehouse
+- `--no-partial-compilation`
+  - Report failures normally handled by partial compilation as errors
 - `--ignore-errors`
   - (default: false)
   - Allows deploy with errors on compile
@@ -399,6 +433,11 @@ All standard [dbt options](#dbt-options) work with `lightdash start-preview`.
 - `--use-dbt-list [true/false]`
   - (default: true)
   - Use `dbt list` instead of `dbt compile` to generate dbt manifest.json
+- `--validate-warehouse-columns`
+  - (default: false)
+  - Validate supported physical `${TABLE}.column` references against the warehouse
+- `--no-partial-compilation`
+  - Report failures normally handled by partial compilation as errors
 - `--ignore-errors`
   - (default: false)
   - Allows deploy with errors on compile
@@ -490,6 +529,11 @@ All standard [dbt options](#dbt-options) work with `lightdash deploy`.
   - Use `dbt list` instead of `dbt compile` to generate dbt manifest.json
 - `--combine-manifest <path-or-url>`
   - Path or http(s) URL to an additional dbt `manifest.json`. Models present in this file but missing from the deploy-generated manifest are merged in so the deploy reflects the full project even when dbt was only run on a subset of models. The deploy-generated manifest always wins on conflicts. URLs (for example, a presigned S3 URL) are fetched at runtime so the manifest does not need to be downloaded first.
+- `--validate-warehouse-columns`
+  - (default: false)
+  - Validate supported physical `${TABLE}.column` references against the warehouse
+- `--no-partial-compilation`
+  - Report failures normally handled by partial compilation as errors
 - `--use-batched-deploy`
   - (default: false)
   - Deploy explores in batches instead of a single request. Useful for large projects that exceed payload size limits
@@ -572,6 +616,11 @@ All standard [dbt options](#dbt-options) work with `lightdash validate`.
 - `--only [elems...]`
   - (default: ["charts","dashboards","tables"])
   - Specify project elements to validate
+- `--validate-warehouse-columns`
+  - (default: false)
+  - Validate supported physical `${TABLE}.column` references. Tables are included in validation by default; when using `--only`, the list must include `tables`
+- `--no-partial-compilation`
+  - Report failures normally handled by partial compilation as errors
 - `--include-spaces <spaceSlugs...>`
   - Only report chart and dashboard validation errors from these spaces. Matching cascades recursively into sub-spaces via parent space relationships, so passing a parent space slug also includes everything under it. Use the same `spaceSlug` identifiers that appear in `lightdash download` output. Space slugs aren't unique — if the same slug exists in multiple spaces, all of them (and their sub-spaces) are matched. Mutually exclusive with `--exclude-spaces`.
 - `--exclude-spaces <spaceSlugs...>`
@@ -1398,6 +1447,10 @@ You can set the number of threads for dbt in Lightdash commands that support dbt
 ## Environment Variables
 
 The Lightdash CLI supports various environment variables that can be used to configure its behavior. These are especially useful in CI/CD environments where you want to avoid interactive prompts or need to set credentials programmatically.
+
+<Warning>
+  `PARTIAL_COMPILATION_ENABLED` is no longer supported. Remove it from CLI and self-hosted deployment configuration. It no longer controls server or CLI behavior. Project create, update, and refresh paths use partial compilation, and CLI compilation uses it by default. Use [`--no-partial-compilation`](#partial-compilation) on a supported CLI command to report failures normally handled by partial compilation as errors for that run.
+</Warning>
 
 ### Core Lightdash Configuration
 

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -161,7 +161,10 @@ Enable or disable individual product features across the instance.
 | `ECHARTS_V6_ENABLED`                         | Opt into the ECharts v6 renderer. (default=false)                                                                                                                                                                                    |
 | `FUNNEL_BUILDER_ENABLED`                     | Enables the funnel chart builder. (default=false)                                                                                                                                                                                    |
 | `SAVE_CREDENTIALS_FORM_ENABLED`              | Enables the "save credentials" form so warehouse credentials can be stored per-user. (default=false)                                                                                                                                 |
-| `PARTIAL_COMPILATION_ENABLED`                | Compile only changed dbt models when refreshing a project. (default=true)                                                                                                                                                            |
+
+<Note>
+  `PARTIAL_COMPILATION_ENABLED` has been removed and no longer controls server or CLI behavior. Project create, update, and refresh paths use partial compilation, and CLI compilation uses it by default. To report failures normally handled by partial compilation as errors in a supported CLI command, use [`--no-partial-compilation`](/references/lightdash-cli#partial-compilation) for that run.
+</Note>
 
 ## Feature flags
 


### PR DESCRIPTION
## Summary

- Document partial versus strict compilation across CLI reference and workflow guides.
- Document `--validate-warehouse-columns`, supported references, probe behavior, and skip conditions.
- Remove `PARTIAL_COMPILATION_ENABLED` from the self-hosted environment-variable reference and explain migration to `--no-partial-compilation`.

## Verification

- `node scripts/check-links.js`
- `node scripts/check-image-locations.js`
- Read-only factual review against merged Lightdash implementation: no findings.