### PR TITLE
docs: document inTheCurrent / notInTheCurrent dbt YAML filter operators

### DIFF
--- a/references/metrics.mdx
+++ b/references/metrics.mdx
@@ -2030,6 +2030,8 @@ These filters do not appear in the `Filters` tab in the Explore view, instead, t
 | is greater than (number)      | Number of orders is greater than 4             | `num_orders: "> 4"`          |
 | in the past (date) (interval) | Date is before x (days / months / years)       | `date: "inThePast 14 months"` |
 | in the next (date) (interval) | Date is after x (days / months / years)        | `date: "inTheNext 14 days"`   |
+| in the current (date) (unit)  | Date is in the current (day / week / month / quarter / year) | `date: "inTheCurrent month"`  |
+| not in the current (date) (unit) | Date is not in the current (day / week / month / quarter / year) | `date: "notInTheCurrent year"` |
 | is greater than or equal to   | Number of orders is greater than or equal to 4 | `num_orders: ">= 4"`         |
 | is less than                  | Number of orders is less than 4                | `num_orders: "< 4"`          |
 | is less than or equal to      | Number of orders is less than or equal to 4    | `num_orders: "<= 4"`         |
@@ -2046,6 +2048,13 @@ For date filtering, use `inThePast` or `inTheNext` followed by a number and time
 ```yaml
 filters:
   - created_at: 'inThePast 30 days'
+```
+
+To filter dynamically to the current time period, use `inTheCurrent` or `notInTheCurrent` followed by a unit of time (`day`, `week`, `month`, `quarter`, or `year`) — no number needed.
+
+```yaml
+filters:
+  - created_at: 'inTheCurrent month'
 ```
 
 ### Special characters in filters

--- a/references/tables.mdx
+++ b/references/tables.mdx
@@ -826,6 +826,8 @@ Note that we do also support a _legacy_ structure for defining required filters,
 | is less than or equal to      | Number is less than or equal to value          | `num_orders: "<= 4"` | Number                |
 | in the past     | Date is before x (days / months / years)       | `date: "inThePast 14 days"`         | Date                  |
 | in the next     | Date is after x (days / months / years)        | `date: "inTheNext 30 days"`         | Date                  |
+| in the current  | Date is in the current (day / week / month / quarter / year) | `date: "inTheCurrent day"`          | Date                  |
+| not in the current | Date is not in the current (day / week / month / quarter / year) | `date: "notInTheCurrent week"`      | Date                  |
 | is null         | Value is NULL                                  | `status: "null"`                    | All                   |
 | is not null     | Value is not NULL                              | `status: "!null"`                  | All             |
 | is empty        | Value is empty string                          | `notes: "empty"`                    | String          |
@@ -890,6 +892,18 @@ default_filters:
 ```
 
 Available intervals: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, `weeks`, `months`, `years`
+
+**Current time period (no value needed):**
+
+Use `inTheCurrent` / `notInTheCurrent` to filter dynamically to the current time period. These operators take no number — just a unit of time (singular or plural).
+
+```yaml
+default_filters:
+  - order_date: 'inTheCurrent day'
+  - order_date: 'notInTheCurrent month'
+```
+
+Available units: `day`, `week`, `month`, `quarter`, `year`
 
 **Complex example with multiple filters:**
 


### PR DESCRIPTION
## Description

Documents the value-less relative date operators `inTheCurrent` / `notInTheCurrent` added to the dbt YAML filter grammar in lightdash/lightdash#26237.

- **references/tables.mdx** — added both operators to the "Available filter types" table and a "Current time period (no value needed)" example under filter examples
- **references/metrics.mdx** — added both operators to the metric filter types table and extended the "Date filters" section with an example

Units accepted: `day`, `week`, `month`, `quarter`, `year` (singular or plural).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoDEz71hKmUNpSYbbFa91n