### PR TITLE
docs: self-hosted guide for the organization roadmap (egress allowlist + enablement)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -365,6 +365,7 @@
                   "self-host/customize-deployment/configure-smtp-for-lightdash-email-notifications",
                   "self-host/customize-deployment/configure-standalone-scheduled-worker",
                   "self-host/customize-deployment/enable-headless-browser-for-lightdash",
+                  "self-host/customize-deployment/enable-organization-roadmap",
                   "self-host/customize-deployment/enable-scheduler-in-self-hosted-lightdash",
                   "self-host/customize-deployment/environment-variables",
                   "self-host/customize-deployment/google-sheets-integration",

--- a/self-host/customize-deployment/enable-organization-roadmap.mdx
+++ b/self-host/customize-deployment/enable-organization-roadmap.mdx
@@ -1,0 +1,45 @@
+---
+title: "Enable the organization roadmap"
+description: "Give your organization an in-product view of the feature requests it has raised with Lightdash and where each one stands."
+sidebarTitle: Organization roadmap
+
+boost: 0.001
+---
+
+<Note>
+🛠 This page is for engineering teams self-hosting their own Lightdash instance. The organization roadmap is an Enterprise feature and is currently in beta.
+</Note>
+
+The organization roadmap is a read-only page under **Settings → Roadmap** where organization admins can see every feature request their organization has raised with Lightdash, its current status (Backlog, Building, Shipped, Canceled), and links to the public GitHub issue and delivering pull request.
+
+The data is served by a Lightdash-operated roadmap service. Your instance's backend fetches it on behalf of signed-in users — your browser never connects to the service directly, and the service never connects to your instance.
+
+## Requirements
+
+1. **An Enterprise license key** — the roadmap service authenticates your instance with the same [Enterprise license key](/self-host/customize-deployment/enterprise-license-keys) your deployment already uses.
+2. **Your organization enabled on the roadmap service** — your license must be linked to your organization on the Lightdash side. Contact your Lightdash representative to get this set up. Until then, the Roadmap page shows "Your roadmap isn't set up yet".
+3. **The feature flag enabled** on your backend and scheduler containers:
+
+```bash
+LIGHTDASH_ENABLE_FEATURE_FLAGS=organization-roadmap
+```
+
+If you already enable other feature flags, append it comma-separated:
+
+```bash
+LIGHTDASH_ENABLE_FEATURE_FLAGS=existing-flag,organization-roadmap
+```
+
+## Network egress
+
+If your environment restricts outbound traffic, allow HTTPS (port 443) from your Lightdash backend to:
+
+```
+https://roadmap.lightdash.com
+```
+
+This is outbound-only and read-only: your instance requests your organization's roadmap and receives curated data back. No data about your instance, users, or usage is sent beyond the license key used for authentication.
+
+## What your organization can see
+
+Only your own organization's feature requests are returned — each instance's license is bound to its organization on the service side, and requests for any other organization are refused. Items only appear on the roadmap once they have a public GitHub issue, and the fields shown (title, description, status, links) are limited to what is already public there.

--- a/self-host/customize-deployment/enterprise-license-keys.mdx
+++ b/self-host/customize-deployment/enterprise-license-keys.mdx
@@ -65,7 +65,9 @@ On server start, Lightdash validates your Enterprise License Key by making an ou
 - **When:** On every Lightdash server start
 
 <Note>
-Your Lightdash instance must be able to reach `https://api.keygen.sh` on server start. This is the **only** external network request required to run Lightdash with enterprise features. If your environment restricts outbound traffic, ensure this endpoint is allowlisted in your firewall or proxy configuration.
+Your Lightdash instance must be able to reach `https://api.keygen.sh` on server start. This is the only external network request **required** to run Lightdash with enterprise features. If your environment restricts outbound traffic, ensure this endpoint is allowlisted in your firewall or proxy configuration.
+
+If you enable the optional [organization roadmap](/self-host/customize-deployment/enable-organization-roadmap), your backend also makes outbound requests to `https://roadmap.lightdash.com` — allowlist that domain too.
 </Note>
 
 No external code is pulled during this process — the request solely validates your license key and returns the validation result.

--- a/self-host/production-deployment-checklist.mdx
+++ b/self-host/production-deployment-checklist.mdx
@@ -303,7 +303,7 @@ Also consider:
 - **CSP enforcement:** `LIGHTDASH_CSP_REPORT_ONLY: "false"` (default is report-only; enforce in production), plus `LIGHTDASH_CSP_ALLOWED_DOMAINS` for any extra origins you load from
 - **CORS:** leave disabled unless embedding; if embedding, `LIGHTDASH_CORS_ENABLED:
       "true"` with an explicit `LIGHTDASH_CORS_ALLOWED_DOMAINS` list — never `*`
-- Egress policy: Lightdash needs your warehouse, S3, SMTP, `api.keygen.sh` (license), your IdP, and any AI provider endpoints — everything else can be blocked
+- Egress policy: Lightdash needs your warehouse, S3, SMTP, `api.keygen.sh` (license), your IdP, and any AI provider endpoints — plus `roadmap.lightdash.com` if you enable the [organization roadmap](/self-host/customize-deployment/enable-organization-roadmap) — everything else can be blocked
 - NetworkPolicies: the chart only ships one for NATS (keep `nats.networkPolicy.enabled:
       true`, the default); add your own default-deny \+ allow rules for backend ↔ postgres/browserless/S3 if your cluster uses them
 - `podSecurityContext` / `securityContext`: the chart sets none by default — add `runAsNonRoot`, drop capabilities per your Pod Security Standards baseline


### PR DESCRIPTION
## Summary

Self-hosted documentation for the new organization roadmap (Enterprise, beta):

- New page **Self-host → Customize deployment → Organization roadmap**: what the feature is, requirements (EE license, org enabled on the roadmap service, `organization-roadmap` feature flag), the exact egress domain to allowlist (`roadmap.lightdash.com`, outbound-only HTTPS), and what data is/isn't exchanged.
- `enterprise-license-keys.mdx`: the "only external network request" claim now scoped to *required* requests, with a pointer to the optional roadmap domain.
- `production-deployment-checklist.mdx`: egress policy list includes the roadmap domain.

Statuses and behavior verified against the shipped implementation (`RoadmapItemStatus` enum, license↔org binding, unbound-org empty state).

`mint broken-links` passes; `docs.json` valid.

Relates: CS-43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AudGgVyb7S2cjVN9DnyjHZ