### PR TITLE
Add private-address failure mode to self-hosted MCP troubleshooting

### DIFF
--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -151,16 +151,17 @@ MCP connections are validated and tested **server-side from the Lightdash backen
 
 This means the **Lightdash backend container** must be able to reach every MCP endpoint you connect. On self-hosted deployments with restricted network egress, connection tests can fail even though the URL works fine from your laptop.
 
-Two common failures:
+Three common failures:
 
 | Error | What it means | Fix |
 | ----- | ------------- | --- |
 | **"We couldn't find a server at that URL"** | The backend's DNS lookup for the endpoint host failed — typically an internal hostname (e.g. `agentic-gateway.internal`) that the backend container can't resolve. | Configure DNS resolution and network routing from the backend pod to that host. |
 | **"fetch failed"** | DNS resolves, but the outbound HTTPS request from the backend container is blocked. | Allow outbound HTTPS (port 443) from the backend pod to the endpoint. |
+| **"MCP servers must use a public URL. Localhost and private network addresses are not supported."** | The endpoint resolves to a private or internal IP address, which is blocked by default as an SSRF safeguard. | On self-hosted deployments (v0.3234.0+), set [`AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES=true`](/self-host/customize-deployment/environment-variables#ai-analyst) to allow MCP servers on private networks. |
 
 To resolve these, work with whoever owns your infrastructure to:
 
-- **Internal MCP endpoints** — configure DNS resolution and network routing from the Lightdash backend pod to the internal host.
+- **Internal MCP endpoints** — configure DNS resolution and network routing from the Lightdash backend pod to the internal host, and set [`AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES=true`](/self-host/customize-deployment/environment-variables#ai-analyst) if the host resolves to a private IP.
 - **External MCP endpoints** (e.g. `https://docs.lightdash.com/mcp`) — allow outbound HTTPS (port 443) egress from the backend pod to the public internet.
 
 <Tip>


### PR DESCRIPTION
Follow-up to #886, which was drafted before `AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES` shipped in 0.3234.0 (lightdash/lightdash#24660) and so missed the third self-hosted failure mode.

Adds the **"MCP servers must use a public URL"** error to the troubleshooting table — endpoints resolving to private/internal IPs are blocked by default as an SSRF safeguard — pointing self-hosted operators at [`AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES=true`](https://docs.lightdash.com/self-host/customize-deployment/environment-variables#ai-analyst) in the env-vars reference. Also mentions the flag in the internal-endpoints setup bullet, since internal hostnames typically resolve to private IPs and hit this error right after DNS is fixed.

Error string and env var verified against `packages/backend/src/utils/ssrfProtection.ts` and `parseConfig.ts`.

Linear: PROD-8453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uw5xueaZQbYnZUQ1iVkYyH