### PR TITLE
docs: fix 'slice and dice' typo in semantic layer guide

### DIFF
--- a/guides/lightdash-semantic-layer.mdx
+++ b/guides/lightdash-semantic-layer.mdx
@@ -107,7 +107,7 @@ For programmatic access, you can use the [Lightdash API](/api-reference/v1/intro
 - **Self-service that actually works:** Explore data without needing to know SQL or complex data structures, and interact with metrics that are relevant to their work.
 - **Trust the numbers:** Feel confident that metrics are correctly calculated and consistent.
 - **Find what you need:** Easily discover relevant metrics and dimensions with clear descriptions.
-- **Slice and eice on your own:** Analyze data without waiting for the data team to help.
+- **Slice and dice on your own:** Analyze data without waiting for the data team to help.
 - **See the context:** Access metadata about metrics like who owns them and when they were last updated.
 - **Speak business, not tech:** Interact with data using terms that make sense to you.
 


### PR DESCRIPTION
## Summary
Fixes a typo on the [/guides/lightdash-semantic-layer](https://docs.lightdash.com/guides/lightdash-semantic-layer) page: "Slice and **eice** on your own" → "Slice and **dice** on your own".

Closes #591
Fixes AE-298

🤖 Generated with [Claude Code](https://claude.com/claude-code)