### PR TITLE
docs(ai-agents): document Slack MCP server setup

### DIFF
--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -67,26 +67,31 @@ MCP servers are configured per project and can be attached to one or more agents
 
 ## Connect the Slack MCP server
 
-Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. If your workspace already has a Slack app your team owns (for example a self-hosted deployment's [Slack integration](/references/integrations/slack-integration) app), you can reuse it; otherwise create an internal app at [api.slack.com/apps](https://api.slack.com/apps).
-
-<Note>
-  On Lightdash Cloud, the Slack integration app is provisioned and owned by Lightdash, so it can't be reused for MCP — create a dedicated internal Slack app in your workspace instead.
-</Note>
+Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. The steps below walk through creating an internal Slack app and connecting it to Lightdash.
 
 <Steps>
-  <Step title="Get the app's client credentials">
-    In your Slack app settings, go to **Basic Information → App Credentials** and copy the **Client ID** and **Client Secret**.
+  <Step title="Create a Slack app">
+    Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App → From scratch**, give it a name (e.g. `Lightdash AI`), and pick your workspace. Because the app is created in your own workspace it counts as an internal app, which is what makes it eligible for Slack MCP access.
   </Step>
   <Step title="Add the Lightdash callback as a redirect URL">
-    Go to **OAuth & Permissions → Redirect URLs**, add `https://<instance-name>.lightdash.cloud/api/v1/aiAgents/mcp/oauth/callback` (or your own URL if self-hosting), and click **Save URLs**. Slack matches the URI exactly — if this step is missed you'll see `redirect_uri did not match any configured URIs` during sign-in.
+    In the app settings, go to **OAuth & Permissions → Redirect URLs**, add `https://<instance-name>.lightdash.cloud/api/v1/aiAgents/mcp/oauth/callback` (replace the host with your own URL if self-hosting), and click **Save URLs**. Slack matches the URI exactly — if this step is missed you'll see `redirect_uri did not match any configured URIs` during sign-in.
   </Step>
   <Step title="Enable Slack MCP server access for the app">
     On the app's **Agents & AI Apps** page (`https://api.slack.com/apps/<app-id>/app-assistant`), enable access to the Slack MCP server. If this is skipped, sign-in completes but the connection then fails with `App is not enabled for Slack MCP server access`.
   </Step>
+  <Step title="Copy the app's client credentials">
+    Go to **Basic Information → App Credentials** and copy the **Client ID** and **Client Secret**.
+  </Step>
   <Step title="Create the MCP server in Lightdash">
-    Follow [Add an MCP server](#add-an-mcp-server) with URL `https://mcp.slack.com/mcp` and auth type **OAuth**, then open **More options** and paste the **Client ID** and **Client secret** from step 1. Click **Create and connect** and sign in with your Slack account. If the client ID and secret are missing, the connection fails with `Incompatible auth server: does not support dynamic client registration`.
+    Follow [Add an MCP server](#add-an-mcp-server) with URL `https://mcp.slack.com/mcp` and auth type **OAuth**, then open **More options** and paste the **Client ID** and **Client secret** from the previous step. Click **Create and connect** and sign in with your Slack account. If the client ID and secret are missing, the connection fails with `Incompatible auth server: does not support dynamic client registration`.
   </Step>
 </Steps>
+
+You don't need to configure scopes on the app or install it to your workspace first — Slack requests the user scopes its MCP tools need during sign-in, and every user connects with their own account, so agents only see what that user can see in Slack. If your workspace restricts app installs, a Slack admin may need to approve the app the first time someone connects.
+
+<Note>
+  **Self-hosting?** If you set up a Slack app for the [Slack integration](/references/integrations/slack-integration), you can reuse it here instead of creating a new one — it's already an internal app in your workspace. Skip step 1 and apply steps 2–4 to that app.
+</Note>
 
 ## How credentials work
 

--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -71,7 +71,7 @@ Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than mo
 
 <Steps>
   <Step title="Create a Slack app">
-    Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App → From scratch**, give it a name (e.g. `Lightdash AI`), and pick your workspace. Because the app is created in your own workspace it counts as an internal app, which is what makes it eligible for Slack MCP access.
+    Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App → From scratch**, give it a name (e.g. `Lightdash AI`), and pick your workspace.
   </Step>
   <Step title="Add the Lightdash callback as a redirect URL">
     In the app settings, go to **OAuth & Permissions → Redirect URLs**, add `https://<instance-name>.lightdash.cloud/api/v1/aiAgents/mcp/oauth/callback` (replace the host with your own URL if self-hosting), and click **Save URLs**. Slack matches the URI exactly — if this step is missed you'll see `redirect_uri did not match any configured URIs` during sign-in.

--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -70,7 +70,7 @@ MCP servers are configured per project and can be attached to one or more agents
 Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. If your workspace already has a Slack app your team owns (for example a self-hosted deployment's [Slack integration](/references/integrations/slack-integration) app), you can reuse it; otherwise create an internal app at [api.slack.com/apps](https://api.slack.com/apps).
 
 <Note>
-  If your Slack integration uses the shared Lightdash Cloud Slack app, you can't reuse it for MCP — its credentials belong to Lightdash. Create a dedicated internal Slack app in your workspace instead.
+  On Lightdash Cloud, the Slack integration app is provisioned and owned by Lightdash, so it can't be reused for MCP — create a dedicated internal Slack app in your workspace instead.
 </Note>
 
 <Steps>

--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -25,7 +25,8 @@ Once an MCP server is connected to an agent, the agent can use its tools as part
 - **Linear** — file issues from anomalies the agent spots, comment on tickets, query project status. See [Linear MCP docs](https://linear.app/docs/mcp#general).
 - **Confluence** — search the knowledge base for context before answering, or publish summaries. See [Getting started with the Atlassian Remote MCP Server](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/).
 - **Lightdash Docs** — give agents access to the complete Lightdash documentation so they can answer questions about Lightdash concepts, configuration, and best practices. URL: `https://docs.lightdash.com/mcp`, auth type `None`. See [Lightdash Docs MCP](/references/integrations/lightdash-mcp#lightdash-docs-mcp).
-- Any other service that exposes a remote MCP server (GitHub, Jira, Slack, internal tooling, etc.)
+- **Slack** — search channels, threads, and messages so agents can pull team context into answers. Slack requires extra app setup — see [Connect the Slack MCP server](#connect-the-slack-mcp-server).
+- Any other service that exposes a remote MCP server (GitHub, Jira, internal tooling, etc.)
 
 The agent decides when to call MCP tools based on the user's question and the agent's instructions, the same way it decides when to query your data.
 
@@ -61,6 +62,25 @@ MCP servers are configured per project and can be attached to one or more agents
   </Step>
   <Step title="Attach to an agent">
     Edit any agent in the project and select the MCP server under **MCP servers**. The agent will now have access to that server's tools.
+  </Step>
+</Steps>
+
+## Connect the Slack MCP server
+
+Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. If your workspace already has a Slack app (for example the one used by the [Lightdash Slack integration](/references/integrations/slack-integration)), you can reuse it; otherwise create one at [api.slack.com/apps](https://api.slack.com/apps).
+
+<Steps>
+  <Step title="Get the app's client credentials">
+    In your Slack app settings, go to **Basic Information → App Credentials** and copy the **Client ID** and **Client Secret**.
+  </Step>
+  <Step title="Add the Lightdash callback as a redirect URL">
+    Go to **OAuth & Permissions → Redirect URLs**, add `https://<instance-name>.lightdash.cloud/api/v1/aiAgents/mcp/oauth/callback` (or your own URL if self-hosting), and click **Save URLs**. Slack matches the URI exactly — if this step is missed you'll see `redirect_uri did not match any configured URIs` during sign-in.
+  </Step>
+  <Step title="Enable Slack MCP server access for the app">
+    On the app's **Agents & AI Apps** page (`https://api.slack.com/apps/<app-id>/app-assistant`), enable access to the Slack MCP server. If this is skipped, sign-in completes but the connection then fails with `App is not enabled for Slack MCP server access`.
+  </Step>
+  <Step title="Create the MCP server in Lightdash">
+    Follow [Add an MCP server](#add-an-mcp-server) with URL `https://mcp.slack.com/mcp` and auth type **OAuth**, then open **More options** and paste the **Client ID** and **Client secret** from step 1. Click **Create and connect** and sign in with your Slack account. If the client ID and secret are missing, the connection fails with `Incompatible auth server: does not support dynamic client registration`.
   </Step>
 </Steps>
 

--- a/guides/ai-agents/mcp-servers.mdx
+++ b/guides/ai-agents/mcp-servers.mdx
@@ -67,7 +67,11 @@ MCP servers are configured per project and can be attached to one or more agents
 
 ## Connect the Slack MCP server
 
-Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. If your workspace already has a Slack app (for example the one used by the [Lightdash Slack integration](/references/integrations/slack-integration)), you can reuse it; otherwise create one at [api.slack.com/apps](https://api.slack.com/apps).
+Slack's hosted MCP server (`https://mcp.slack.com/mcp`) needs more setup than most providers because Slack [does not support Dynamic Client Registration](https://docs.slack.dev/ai/slack-mcp-server/). You must bring your own OAuth client, and Slack only accepts clients backed by a registered Slack app that is either **published in the Slack Marketplace** or an **internal app** in your workspace — unlisted apps are rejected. If your workspace already has a Slack app your team owns (for example a self-hosted deployment's [Slack integration](/references/integrations/slack-integration) app), you can reuse it; otherwise create an internal app at [api.slack.com/apps](https://api.slack.com/apps).
+
+<Note>
+  If your Slack integration uses the shared Lightdash Cloud Slack app, you can't reuse it for MCP — its credentials belong to Lightdash. Create a dedicated internal Slack app in your workspace instead.
+</Note>
 
 <Steps>
   <Step title="Get the app's client credentials">


### PR DESCRIPTION
## Summary

Adds a **Connect the Slack MCP server** section to the AI agents MCP servers guide, plus a Slack entry in the "What you can do" list.

Slack's hosted MCP server (`https://mcp.slack.com/mcp`) doesn't support Dynamic Client Registration and only accepts Marketplace-published or workspace-internal apps as OAuth clients, so the generic OAuth instructions aren't enough. The new section is a complete walkthrough of the supported flow — creating a new internal Slack app — with each step naming the error you hit if it's missed:

1. **Create an internal Slack app** (internal apps are MCP-eligible; unlisted apps are rejected)
2. **Add the Lightdash callback to Redirect URLs** → otherwise `redirect_uri did not match any configured URIs`
3. **Enable Slack MCP server access on the Agents & AI Apps page** → otherwise `App is not enabled for Slack MCP server access`
4. **Copy client ID/secret** and paste into Lightdash under More options → without them, `Incompatible auth server: does not support dynamic client registration`

A note tells self-hosted users they can reuse their existing Slack integration app (already internal to their workspace) instead of creating a new one.

Process verified end-to-end today connecting the Slack MCP to an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T87vQmdBWDZJcudGRtJRq