### PR TITLE
docs: agents work with parameters

### DIFF
--- a/guides/ai-agents.mdx
+++ b/guides/ai-agents.mdx
@@ -8,7 +8,7 @@ description: "No code, no complex tools, just type what you want to know. AI Age
   AI agents are available as an add-on for all plans. [View pricing](https://www.lightdash.com/pricing)
 </Info>
 
-AI agents automatically select the most relevant data models and metrics to answer your questions, build and execute queries with appropriate dimensions, metrics, and filters, and present results in the most insightful format.
+AI agents automatically select the most relevant data models and metrics to answer your questions, build and execute queries with appropriate dimensions, metrics, filters, and [parameters](/guides/developer/using-parameters), and present results in the most insightful format.
 
 <Note>
   Looking for [**Autopilot**](/guides/ai-agents/autopilot)? Autopilot is a separate, admin-only agent that runs on a schedule to keep your project clean — fixing broken charts, flagging stale content, and suggesting new ones. It is not used to build charts or dashboards from user questions like the conversational AI agents described on this page.

--- a/guides/ai-agents/best-practices.mdx
+++ b/guides/ai-agents/best-practices.mdx
@@ -20,6 +20,7 @@ Good documentation is crucial for AI to understand your data models and provide 
 - **Add detailed descriptions** to all metrics and dimensions explaining what they represent
 - **Include example questions** in descriptions that AI could answer with the metric
 - **Use AI hints** to provide additional context specifically for AI agents
+- **Give [parameters](/guides/developer/using-parameters) clear labels, descriptions, and options** — agents read them when deciding which value to set on a parameter-driven field, and fall back to the default when a question doesn't call for a specific value
 
 Remember: If your colleague wouldn't understand your documentation, neither will the AI agent. The more context you provide, the better the AI can interpret and analyze your data.
 

--- a/guides/ai-agents/using-ai-agents.mdx
+++ b/guides/ai-agents/using-ai-agents.mdx
@@ -87,7 +87,7 @@ This is useful when a dashboard has many charts and you want to drill into one w
 
 ### What you can ask
 
-When you pin a saved chart, the agent can read its actual data (subject to your [data access setting](/guides/ai-agents/data-access)). It honors the chart's saved filters, sorts, and custom metrics, so you can ask:
+When you pin a saved chart, the agent can read its actual data (subject to your [data access setting](/guides/ai-agents/data-access)). It honors the chart's saved filters, sorts, custom metrics, and [parameter values](/guides/developer/using-parameters), so you can ask:
 
 - *"Why is this trending up?"*
 - *"Are there outliers in this chart?"*


### PR DESCRIPTION
AI agents can now discover and set Lightdash parameter values in their queries (lightdash/lightdash#27190), but the agents docs enumerate query capabilities ("dimensions, metrics, and filters") without them — reading as if parameters were unsupported. Deliberately no dedicated parameters section: agents should read as working with everything in Lightdash, so parameters are added only to the existing enumerations, plus one authoring bullet noting that parameter labels/descriptions/options are agent-facing metadata.
