### PR TITLE
docs: expand direct-binary-download instructions for the CLI

### DIFF
--- a/guides/cli/how-to-install-the-lightdash-cli.mdx
+++ b/guides/cli/how-to-install-the-lightdash-cli.mdx
@@ -13,7 +13,7 @@ description: The Lightdash CLI is the recommended way to develop your dbt + Ligh
 
 **Other platforms:** Use the [NPM installation method](#install-via-npm), which works across all platforms but requires Node.js to be installed first.
 
-You can also download the CLI binary directly from GitHub releases if you prefer not to use a package manager.
+You can also download the CLI binary directly from GitHub releases if you prefer not to use a package manager — currently macOS only, see [Download binary directly](#download-binary-directly).
 
 <Frame>
   <iframe width="100%" height="420" src="https://www.loom.com/embed/4b50ff5f986f4808ad0a2527eabfdaad" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen />
@@ -287,7 +287,48 @@ Pick your project from the list, then re-run `lightdash deploy`.
 
 ## Download binary directly
 
-You can also download the CLI binary directly from [GitHub releases](https://github.com/lightdash/lightdash/releases).
+If you don't want to use a package manager, you can download a prebuilt binary directly from [GitHub releases](https://github.com/lightdash/lightdash/releases). Binaries bundle their own Node.js runtime, so **you don't need Node installed** to use them.
+
+<Info>
+  Prebuilt binaries are currently macOS only (Apple Silicon and Intel). If you're on Mac, [Homebrew](#install-via-homebrew) is the easier no-Node option — it wraps the same binary and handles `PATH` and updates for you. Linux users should use [npm](#install-via-npm); Windows users should use [WSL](#install-on-windows-wsl-recommended).
+</Info>
+
+Each release publishes two macOS assets, named for the release version:
+
+- `lightdash-cli-<version>-macos-arm64.tar.gz` — Apple Silicon (M1/M2/M3/M4)
+- `lightdash-cli-<version>-macos-x64.tar.gz` — Intel Macs
+
+<Steps>
+  <Step title="Find your Mac's chip type">
+    ```bash
+    uname -m
+    # arm64   -> Apple Silicon (use the macos-arm64 asset)
+    # x86_64  -> Intel (use the macos-x64 asset)
+    ```
+  </Step>
+
+  <Step title="Download the matching asset">
+    Pick the version you want from the [releases page](https://github.com/lightdash/lightdash/releases), then download it (replace `<version>` and `<arch>`):
+
+    ```bash
+    curl -LO https://github.com/lightdash/lightdash/releases/download/<version>/lightdash-cli-<version>-macos-<arch>.tar.gz
+    ```
+  </Step>
+
+  <Step title="Extract and make it executable">
+    ```bash
+    tar -xzf lightdash-cli-<version>-macos-<arch>.tar.gz
+    chmod +x lightdash-macos-<arch>
+    ```
+  </Step>
+
+  <Step title="Move it onto your PATH">
+    ```bash
+    sudo mv lightdash-macos-<arch> /usr/local/bin/lightdash
+    lightdash --version
+    ```
+  </Step>
+</Steps>
 
 ## Updating the Lightdash CLI
 


### PR DESCRIPTION
## Summary

Expands the one-sentence "Download binary directly" section on the CLI install page into actual usable instructions, per the Node 24 upgrade announcement steering Node-averse users toward Homebrew + direct binary download.

- Lists the real per-platform release assets and shows the download/extract/PATH steps
- Cross-links the existing Homebrew section instead of duplicating it
- States clearly that binaries bundle their own Node runtime (no separate Node install needed)
- Adds a one-line pointer at the top-of-page summary so it doesn't overstate platform coverage

## Asset names — divergence from the ticket

The ticket assumed four platform assets (`lightdash-macos-arm64`, `lightdash-macos-x64`, `lightdash-linux-x64`, `lightdash-win-x64`). I verified against real releases (`gh release view <tag> --json assets`, checked ~15 recent releases) and found:

- **Only macOS binaries are actually published** — no Linux or Windows binaries exist on GitHub releases today (the page's Windows section already notes "The Lightdash CLI doesn't ship a native Windows binary").
- The real, versioned asset names are `lightdash-cli-<version>-macos-arm64.tar.gz` and `lightdash-cli-<version>-macos-x64.tar.gz` (plus a `checksums-macos-sha256.txt`), not the fixed names in the ticket.
- Docs now describe the versioned naming pattern rather than a fixed asset list, and point Linux users to npm and Windows users to WSL since no binary exists for those platforms.

## Test plan

- [x] `node scripts/check-links.js` — no broken internal links
- [x] `node scripts/check-image-locations.js` — no image issues
- [x] Verified asset names/contents against real GitHub releases (downloaded and inspected a tarball)

Linear: PROD-8559