### PR TITLE
chore(ci): update workflow Node runtime to 24

### DIFF
--- a/.github/workflows/fix-image-locations.yml
+++ b/.github/workflows/fix-image-locations.yml
@@ -39,7 +39,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Checkout the actual PR branch, not detached HEAD
           ref: ${{ steps.pr-info.outputs.branch || github.ref }}
@@ -48,9 +48,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Check for image issues
         id: check

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -31,9 +31,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Post initial status comment
         id: initial-comment


### PR DESCRIPTION
Update Actions workflows to Node 24 and refresh their runtime pins; Node 18/20 are past EOL.

Coverage: `.github/workflows/fix-image-locations.yml` is `workflow_call` only, so it is not proven by this PR.

Linear: PROD-10129