### PR TITLE
docs: correct multiple dbt sources docs on collisions, connectors, availability

### DIFF
--- a/get-started/setup-lightdash/connect-project.mdx
+++ b/get-started/setup-lightdash/connect-project.mdx
@@ -1271,7 +1271,7 @@ Connecting Lightdash to a hosted dbt project means that you'll be able to keep y
 The most common way to connect to dbt is to connect to a git repository where your dbt project is hosted. You can also connect directly using the CLI, or using the dbt Cloud connection type which leverages the dbt Cloud API.
 
 <Info>
-  **Need to connect more than one dbt project?** Lightdash supports connecting **multiple dbt sources** to a single project, so tables from different dbt repos appear side-by-side in the same Lightdash project. It's in private beta. Email [support@lightdash.com](mailto:support@lightdash.com) to enable it for your org. See [Connecting multiple dbt sources](/references/integrations/dbt-projects#connecting-multiple-dbt-sources) for details.
+  **Need to connect more than one dbt project?** Lightdash supports connecting **multiple dbt sources** to a single project, so tables from different dbt repos appear side-by-side in the same Lightdash project. It's enabled by default on Lightdash Cloud. Self-hosted deployments need to enable the `multi-dbt-sources` feature flag on v0.3275.0 or later. See [Connecting multiple dbt sources](/references/integrations/dbt-projects#connecting-multiple-dbt-sources) for details.
 </Info>
 
 <Accordion title="I'm using dbt Cloud, should I connect using my git repository or through dbt Cloud?">

--- a/references/integrations/dbt-projects.mdx
+++ b/references/integrations/dbt-projects.mdx
@@ -247,7 +247,7 @@ Each additional source has:
 
 - A **display name**: how it appears in the sources panel and in collision errors.
 - Its own **dbt connection**: GitHub only for now. The primary source can use any of Lightdash's supported connection types (GitHub, GitLab, Azure DevOps, Bitbucket, dbt Cloud), but additional sources are limited to GitHub, each with its own repo, branch, subfolder, credentials, and environment variables.
-- A **precedence**: used to resolve name collisions across sources (see below).
+- A **precedence**: the order in which sources are merged. Collisions fail the deploy rather than being resolved by precedence (see below). Precedence determines which source is reported as holding the existing definition and which as the duplicate.
 
 ### How compilation and merging works
 

--- a/references/integrations/dbt-projects.mdx
+++ b/references/integrations/dbt-projects.mdx
@@ -206,7 +206,7 @@ If you're using the [Lightdash CLI](/guides/cli/how-to-install-the-lightdash-cli
 ## Connecting multiple dbt sources
 
 <Info>
-  **Private beta.** Multiple dbt sources is off by default and enabled per organization. Email [support@lightdash.com](mailto:support@lightdash.com) to have it turned on for your org. Self-hosted deployments need Lightdash v0.3275.0 or later (shipped July 2026).
+  **Availability.** On Lightdash Cloud, multiple dbt sources is enabled by default, so the **dbt sources** panel is already visible in Project Settings. On self-hosted deployments, add `multi-dbt-sources` to your `LIGHTDASH_ENABLE_FEATURE_FLAGS` environment variable (comma-separated, so append it to any flags you already have set) on Lightdash v0.3275.0 or later.
 </Info>
 
 A single Lightdash project can connect to more than one dbt project. Each connected dbt project is called a **dbt source**:
@@ -234,7 +234,7 @@ Go to **Project settings → dbt connection**. When the feature is enabled for y
 
 From the panel you can:
 
-- **Add an additional source**: pick a connection type (GitHub, GitLab, Azure DevOps, Bitbucket, dbt Cloud, and the other types supported for the primary source), give the source a display name, and fill in its repo/branch/subfolder/credentials and any environment variables. Environment variables are validated when the source is saved.
+- **Add an additional source**: connect a GitHub repository, give the source a display name, and fill in its repo/branch/subfolder/credentials and any environment variables. Environment variables are validated when the source is saved. Other connection types aren't supported for additional sources yet.
 - **Edit an additional source**: change its display name, connection details, or environment variables.
 - **Remove an additional source**: additional sources can be removed at any time.
 - **Edit the primary source**: the primary source is edited via the normal dbt connection form. It cannot be removed.
@@ -245,8 +245,8 @@ From the panel you can:
 
 Each additional source has:
 
-- A **display name**: how it appears in the sources panel and in collision warnings.
-- Its own **dbt connection**: same connection types as the primary, with its own repo, branch, subfolder, credentials, and environment variables.
+- A **display name**: how it appears in the sources panel and in collision errors.
+- Its own **dbt connection**: GitHub only for now. The primary source can use any of Lightdash's supported connection types (GitHub, GitLab, Azure DevOps, Bitbucket, dbt Cloud), but additional sources are limited to GitHub, each with its own repo, branch, subfolder, credentials, and environment variables.
 - A **precedence**: used to resolve name collisions across sources (see below).
 
 ### How compilation and merging works
@@ -256,6 +256,10 @@ On refresh, Lightdash compiles every source and merges the resulting manifests i
 **Precedence.** Sources are ordered by precedence. The primary source is always `0` (highest priority). Additional sources are appended after it in the order they were added. Precedence orders the merge for `ref()` and lookup resolution.
 
 **Name collisions.** If the same model name exists in more than one source, **compilation fails** with an error that names each collision and which sources define it (in the form `<section> "<key>" is defined in both "<source A>" and "<source B>"`, listing up to 10 entries and ending with "Rename or remove the duplicate(s) before deploying."). Rename or remove the duplicates in one of the sources before deploying. Only identical dbt built-in macros and docs are merged silently.
+
+<Warning>
+  **The CLI's `--combine-manifest` flag does not fail on collisions.** `lightdash preview` and `lightdash deploy` accept a separate `--combine-manifest <path|url>` flag (see the [CLI reference](/references/lightdash-cli#lightdash-deploy)) that merges an external manifest into the CLI-generated one. That merge is silent: the CLI-generated manifest always wins on conflicts, and any superseded models from the external manifest are dropped with no warning. This is a different mechanism from the additional-sources merge described above.
+</Warning>
 
 **What's merged vs. deduplicated.**
 


### PR DESCRIPTION
## What changed and why

The multiple dbt sources docs (added in #1074, 2026-08-04) made three claims that didn't match shipped behaviour. This corrects all three:

- **Collisions**: the docs already described the server-side hard-fail correctly (a follow-up fix landed in #1075), but never mentioned that the CLI's `--combine-manifest` flag on `lightdash preview`/`lightdash deploy` is a separate mechanism that merges silently, with the CLI-generated manifest always winning and superseded models dropped without a warning. Both paths are now documented, not just one.
- **Connectors**: additional dbt sources support GitHub connections only right now. The docs previously said they supported the same connection types as the primary source.
- **Availability**: multiple dbt sources is enabled by default on Lightdash Cloud (the docs previously said private beta / contact us). Self-hosted still needs the `multi-dbt-sources` feature flag on v0.3275.0 or later, which was already correct and is kept.

Also tightened one adjacent phrase ("collision warnings" → "collision errors") for consistency with the collision correction, since it used the same non-blocking framing.

Linear: SPK-1024