### PR TITLE
docs: mark the self-hosted upgrade pages as Beta

### DIFF
--- a/self-host/upgrade-runbook.mdx
+++ b/self-host/upgrade-runbook.mdx
@@ -2,7 +2,14 @@
 title: "Upgrade runbook"
 sidebarTitle: "Upgrade runbook"
 description: "Step-by-step sequences for upgrading a self-hosted Lightdash deployment on Kubernetes, docker compose, or automation, plus the migration command reference and recovery paths."
+tag: "Beta"
 ---
+
+<Info>
+  **Safety-gated upgrades are in [Beta](/references/workspace/feature-maturity-levels).** Every command on this page ships in a released image and the recovery paths are supported, but we're still refining the workflow on our own instances, so some sequences and outputs will change.
+
+  Feedback shapes where this goes next. [Open an issue](https://github.com/lightdash/lightdash/issues) if a step doesn't fit your deployment.
+</Info>
 
 <Note>
 🛠 This page is for engineering teams self-hosting their own Lightdash instance. If you're on Lightdash Cloud, upgrades are handled for you automatically.

--- a/self-host/upgrade-safety.mdx
+++ b/self-host/upgrade-safety.mdx
@@ -2,7 +2,14 @@
 title: "Upgrade safety and the release-safety artifact"
 sidebarTitle: "Upgrade safety"
 description: "Every Lightdash release publishes a machine-readable safety signal. Learn how to read it, check an upgrade path, and pick the right deployment strategy."
+tag: "Beta"
 ---
+
+<Info>
+  **Release-safety artifacts are in [Beta](/references/workspace/feature-maturity-levels).** The artifacts are published for every release and are safe to read today, but we're still refining how we classify risk and what the artifact carries, so fields and verdicts may change.
+
+  Build automation against it, and keep that automation easy to change. If the artifact doesn't answer a question you need it to, [tell us](https://github.com/lightdash/lightdash/issues).
+</Info>
 
 <Note>
 🛠 This page is for engineering teams self-hosting their own Lightdash instance. If you're on Lightdash Cloud, upgrades are handled for you automatically.


### PR DESCRIPTION
The upgrade safety and upgrade runbook pages read as stable documentation. The release-safety signal and the automation around it are still refined internally. The artifact fields, the risk verdicts and the runbook sequences can change.

We point self-hosted operators at these pages directly. They must know the maturity level before they build a deployment pipeline on the artifact.

## Changes

- Add `tag: "Beta"` to the frontmatter of `self-host/upgrade-safety.mdx` and `self-host/upgrade-runbook.mdx`. This shows a Beta badge in the sidebar, which is the convention already used on other Beta pages in this repo.
- Add an `<Info>` callout to each page. Each callout links to the feature maturity levels page and asks for feedback.

The two callouts have a different scope on purpose. The safety page tells readers to keep their automation easy to change, because the artifact shape can move. The runbook page confirms that the migration and recovery commands ship in released images and are supported. An operator must not hesitate to use `migrate unlock` during an incident.

Linear: SPK-1064