### PR TITLE
docs: add the 1.124.0 row to the upgrade runbook version table

### DIFF
--- a/self-host/upgrade-runbook.mdx
+++ b/self-host/upgrade-runbook.mdx
@@ -35,6 +35,7 @@ Every command on this page is in a released image. Version-fence your runbook ac
 | Capability | Available from |
 | --- | --- |
 | Migration lease runtime, `migrate status`, `migrate wait`, `migrate unlock` | Lightdash `1.123.0` |
+| Migration run ledger, `parked` state | Lightdash `1.124.0` |
 | `migrate preflight` | Lightdash `1.125.0` |
 | `lightdash upgrade-check` | Lightdash CLI `1.126.0` |
 | `/api/v1/livez` and `/api/v1/readyz` probes | Lightdash `1.129.0` |


### PR DESCRIPTION
Linear: SPK-1064

## What is missing today
The runbook's version table says when the migration lease, the preflight check, the upgrade check, and the probe endpoints shipped. It does not say when the migration run ledger and the parked state shipped. Parked is the one state the runbook tells the reader to stop and fetch a human for. A reader on 1.123.x cannot learn from the page that their version does not park.

## What this PR changes
One row in the version table: the migration run ledger and the parked state, available from Lightdash 1.124.0. The row matches the style of the existing rows. Nothing else on the page changes.

Verified against the product repository: the run ledger and the parked state first appear in release 1.124.0 (first tag containing the commit).
