### PR TITLE
docs: add Codex setup for self-hosted data apps

### DIFF
--- a/guides/data-apps.mdx
+++ b/guides/data-apps.mdx
@@ -10,7 +10,7 @@ description: "Build interactive, AI-generated apps on top of your Lightdash sema
   Data apps are free to use during the beta. Pricing after general availability is to be confirmed.
 </Info>
 
-Data apps let you describe what you want in plain English and get back a working, interactive application built on top of your semantic layer. Behind the scenes, Claude generates a React app inside an isolated sandbox and Lightdash serves it back to you in a sandboxed iframe.
+Data apps let you describe what you want in plain English and get back a working, interactive application built on top of your semantic layer. Behind the scenes, a coding agent generates a React app inside an isolated sandbox and Lightdash serves it back to you in a sandboxed iframe. Lightdash Cloud uses Claude; self-hosted operators can also configure OpenAI Codex.
 
 When the app runs, every query goes through Lightdash, so results respect the same permissions, user attributes, and access controls as the rest of your project. Once you're happy with an app, you can move it into a space and share it with the rest of your organization.
 
@@ -58,17 +58,25 @@ The more context you give the agent, the better the result. You can attach sever
 
 ### Choosing a model
 
-Next to the send button, a model picker lets you choose which Claude model runs the generation:
+Next to the send button, a model picker lets you choose which model runs the generation. The available models depend on the coding agent configured for your Lightdash instance.
+
+With Claude:
 
 - **Sonnet** (default) - balanced quality and speed; the right choice for most apps.
 - **Opus** - highest quality, best for complex apps or when you want the agent to make more nuanced design decisions. Slower.
 - **Haiku** - fastest, useful for small tweaks where you don't need the full reasoning of the larger models.
 
-You can change the model on every prompt - including mid-iteration. The agent keeps its memory of what it already built, so switching models doesn't reset the app.
+With Codex on a self-hosted instance:
+
+- **GPT-5.6 Terra** (default) - balanced quality and cost.
+- **GPT-5.6 Sol** - highest quality for complex generation and design work.
+- **GPT-5.6 Luna** - lowest cost for smaller apps and targeted iterations.
+
+You can change the model on every prompt - including mid-iteration. The existing app source remains the starting point, so switching models doesn't reset the app. Self-hosted operators can learn how to select an agent and provider in [Self-hosting Data apps](/guides/data-apps/self-hosting).
 
 ### Iterating on your app
 
-Every prompt you send creates a new version of the app. The agent keeps its working state between versions, so follow-up prompts like "make the header smaller" or "swap the bar chart for a line chart" land as targeted changes instead of full rewrites.
+Every prompt you send creates a new version of the app. The agent works from the current app source, so follow-up prompts like "make the header smaller" or "swap the bar chart for a line chart" land as targeted changes instead of full rewrites.
 
 If a build is taking too long or going in the wrong direction, you can cancel it and try a different prompt.
 
@@ -270,7 +278,7 @@ Data apps don't ship with their own copy of your data. They run inside a sandbox
 This means:
 
 - **Permissions are enforced by Lightdash, not the app.** Whoever opens the app sees data based on their own role, group memberships, and user attributes - exactly as if they had run the query themselves in an explore.
-- **The agent generates code, not data.** When the app is being built, Claude sees your dbt model catalog (tables, dimensions, metrics) and any context you attach to the prompt. It writes queries against your semantic layer; it does not get a dump of your warehouse.
+- **The agent generates code, not data.** When the app is being built, the configured coding agent sees your dbt model catalog (tables, dimensions, metrics) and any context you attach to the prompt. It writes queries against your semantic layer; it does not get a dump of your warehouse.
 - **The agent can see anything you attach.** Charts, dashboards, images, and sample data you include in the prompt are passed to the agent as context. Don't include data you wouldn't be comfortable sending to the model.
 
 ## Best practices

--- a/guides/data-apps/self-hosting.mdx
+++ b/guides/data-apps/self-hosting.mdx
@@ -8,14 +8,14 @@ description: "Configure your self-hosted Lightdash instance to run Data apps."
   Data apps are an **enterprise** feature. You'll need a valid `LIGHTDASH_LICENSE_KEY` set on your instance before any of the configuration below takes effect.
 </Info>
 
-Data apps are AI-generated React code, produced inside an isolated [E2B](https://e2b.dev/) sandbox, built with Vite, and stored in an S3-compatible bucket. To enable the feature on a self-hosted Lightdash instance you need to bring your own E2B and Claude credentials (via Anthropic or AWS Bedrock), and point Lightdash at a bucket it can write to.
+Data apps are AI-generated React code, produced inside an isolated [E2B](https://e2b.dev/) sandbox, built with Vite, and stored in an S3-compatible bucket. To enable the feature on a self-hosted Lightdash instance, you need to bring your own E2B and model-provider credentials, and point Lightdash at a bucket it can write to. Claude is the default coding agent, but you can run Data apps with OpenAI Codex instead.
 
 ## Prerequisites
 
 - **Enterprise license** - `LIGHTDASH_LICENSE_KEY` must be set on your instance.
 - **S3-compatible storage** - a bucket Lightdash can write to for app source and built artifacts. If your instance isn't already using S3, [set that up first](/self-host/customize-deployment/configure-lightdash-to-use-external-object-storage).
 - **An E2B account** - sign up at [e2b.dev](https://e2b.dev/) and create an API key. E2B is the sandbox provider we use to build the apps.
-- **A Claude provider** - either an [Anthropic](https://console.anthropic.com/) API key or an [AWS Bedrock](https://aws.amazon.com/bedrock/) account with Claude Sonnet access enabled. Claude is the model that writes the React code inside the sandbox.
+- **A coding-agent provider** - Anthropic, OpenAI, or an [AWS Bedrock](https://aws.amazon.com/bedrock/) account with access to the model used by your selected agent.
 
 ## Configuration
 
@@ -24,32 +24,57 @@ Add the following environment variables to your Lightdash deployment:
 | Variable | Example | Purpose |
 | --- | --- | --- |
 | `APPS_RUNTIME_ENABLED` | `true` | Main switch for the feature. |
+| `APPS_CODING_AGENT` | `claude` | Coding agent used to generate apps. Supports `claude` (default) or `codex`. |
 | `APPS_S3_BUCKET` | `lightdash-apps` | Bucket Lightdash will write app source and built artifacts to. Falls back to `S3_BUCKET` if unset - set this if you want a dedicated bucket. |
 | `E2B_API_KEY` | `<your-e2b-api-key>` | Your [E2B](https://e2b.dev/) API key. E2B is the sandbox provider where we generate and build the apps. |
 | `E2B_TEMPLATE_NAME` | `lightdash/lightdash-data-app` | Lightdash's public E2B template - pulls our prebuilt sandbox image so you don't have to build one yourself. |
 
-You also need to configure a Claude provider. Pick one of the two options below.
+Choose one of the coding-agent and provider combinations below.
 
-### Option A: Anthropic (default)
+### Claude through Anthropic (default)
 
-| Variable | Example | Purpose |
-| --- | --- | --- |
-| `ANTHROPIC_API_KEY` | `<your-anthropic-api-key>` | Your [Anthropic](https://console.anthropic.com/) API key. Used when `AI_DEFAULT_PROVIDER` is unset or set to anything other than `bedrock`. |
-
-### Option B: AWS Bedrock
-
-Set `AI_DEFAULT_PROVIDER=bedrock` to route data app generation through AWS Bedrock instead of the Anthropic API. Use a region where Claude Sonnet access is enabled on your AWS account.
+Leave `APPS_CODING_AGENT` unset or set it to `claude`, then provide an Anthropic API key.
 
 | Variable | Example | Purpose |
 | --- | --- | --- |
-| `AI_DEFAULT_PROVIDER` | `bedrock` | Switches both AI Analyst and data apps to Bedrock. |
-| `BEDROCK_REGION` | `us-east-1` | **(Required)** AWS region with Claude Sonnet access enabled. |
+| `APPS_CODING_AGENT` | `claude` | Optional. Claude is used when this variable is unset. |
+| `ANTHROPIC_API_KEY` | `<your-anthropic-api-key>` | Your [Anthropic](https://console.anthropic.com/) API key. Used for Data apps when `AI_DEFAULT_PROVIDER` is not `bedrock`. |
+
+Users can choose Sonnet, Opus, or Haiku for each generation. Sonnet is the default.
+
+### Codex through OpenAI
+
+Set `APPS_CODING_AGENT=codex` and provide an OpenAI API key. Codex uses OpenAI directly whenever `AI_DEFAULT_PROVIDER` is not `bedrock`. You do not need an Anthropic API key for Data app generation in this mode.
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `APPS_CODING_AGENT` | `codex` | Runs Data app generation with OpenAI Codex. |
+| `OPENAI_API_KEY` | `<your-openai-api-key>` | Your [OpenAI API key](https://platform.openai.com/api-keys). |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Optional. Override this for an OpenAI-compatible gateway that supports the Responses API and the configured Codex model IDs. |
+
+Users can choose GPT-5.6 Sol, Terra, or Luna for each generation. Terra is the default.
+
+### Claude or Codex through AWS Bedrock
+
+Set `AI_DEFAULT_PROVIDER=bedrock` to route the selected coding agent through AWS Bedrock. Set `APPS_CODING_AGENT` to `claude` or `codex`, then use a region where the corresponding models are available to your AWS account.
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `APPS_CODING_AGENT` | `claude` | Selects `claude` or `codex`. Defaults to `claude`. |
+| `AI_DEFAULT_PROVIDER` | `bedrock` | Switches both AI Analyst and Data apps to Bedrock. |
+| `BEDROCK_REGION` | `us-east-2` | **(Required)** AWS region where the selected model is available. |
 | `BEDROCK_API_KEY` | `<your-bedrock-api-key>` | Bedrock API key (bearer token). Simplest option - use this *or* the IAM keys below, not both. |
 | `BEDROCK_ACCESS_KEY_ID` | `<aws-access-key-id>` | AWS access key ID. Use with `BEDROCK_SECRET_ACCESS_KEY` as an alternative to `BEDROCK_API_KEY`. |
 | `BEDROCK_SECRET_ACCESS_KEY` | `<aws-secret-access-key>` | AWS secret access key paired with `BEDROCK_ACCESS_KEY_ID`. |
 | `BEDROCK_SESSION_TOKEN` | `<aws-session-token>` | Optional. AWS session token for temporary IAM credentials. |
 
-The Bedrock credentials are the same ones used by AI Analyst - see [AWS Bedrock configuration](/self-host/customize-deployment/environment-variables#aws-bedrock-configuration) for the full reference. The sandbox firewall is automatically updated to allow outbound traffic to the Bedrock runtime hosts for your region.
+For Claude, enable the Claude models you want to use in the selected region. For Codex, enable the corresponding OpenAI model IDs, such as `openai.gpt-5.6-terra`, through the Amazon Bedrock Mantle path. See [OpenAI's Amazon Bedrock guide](https://learn.chatgpt.com/docs/amazon-bedrock) for supported models and authentication requirements.
+
+The Bedrock credentials are the same ones used by AI Analyst - see [AWS Bedrock configuration](/self-host/customize-deployment/environment-variables#aws-bedrock-configuration) for the full reference. The sandbox firewall automatically allows only the provider endpoints required for the selected agent and region.
+
+<Warning>
+  `AI_DEFAULT_PROVIDER` is an instance-wide setting. Setting it to `bedrock` also routes AI Analyst through Bedrock. `APPS_CODING_AGENT` changes only the coding agent used by Data apps.
+</Warning>
 
 Restart the backend. The "Data apps" entry will appear in the **New** menu for users with the appropriate permission scope.
 
@@ -61,12 +86,12 @@ Restart the backend. The "Data apps" entry will appear in the **New** menu for u
 
 ## Costs
 
-Self-hosting Data apps means you pay E2B and your Claude provider directly:
+Self-hosting Data apps means you pay E2B and your selected model provider directly:
 
 - **E2B** bills per sandbox-second. A typical build runs for 1–15 minutes; sandboxes are paused between iterations and resumed on follow-up prompts.
-- **Anthropic or AWS Bedrock** bills per token. Each generation sends the project's dbt catalog and the user's prompt to Claude, plus any attached charts, dashboards, or images.
+- **Anthropic, OpenAI, or AWS Bedrock** bills per token. Each generation sends the project's dbt catalog and the user's prompt to the selected coding agent, plus any attached charts, dashboards, or images.
 
-Both providers expose usage dashboards. We recommend setting spend limits on both before rolling the feature out to your users.
+Both E2B and your model provider expose usage dashboards. We recommend setting spend limits on both before rolling the feature out to your users.
 
 ## Permissions
 
@@ -83,5 +108,8 @@ Verify `E2B_API_KEY` is valid and that your E2B account has access to the `light
 **Builds fail mid-generation with an Anthropic error.**
 Check your Anthropic account usage limits and confirm `ANTHROPIC_API_KEY` is valid. Long-running generations can hit rate limits on lower-tier Anthropic plans.
 
+**Codex builds fail with an OpenAI authentication or model error.**
+Confirm `APPS_CODING_AGENT=codex`, `OPENAI_API_KEY` is valid, and your OpenAI project can use the selected GPT-5.6 model. If you set `OPENAI_BASE_URL`, the gateway must support the Responses API and the model IDs shown in the Data app model picker.
+
 **Builds fail mid-generation with a Bedrock error.**
-Confirm `BEDROCK_REGION` is set to a region where Claude Sonnet access is enabled, and that either `BEDROCK_API_KEY` or the `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` pair is valid. If you use IAM credentials, the principal must have permission to invoke Claude models on Bedrock.
+Confirm `BEDROCK_REGION` is set to a region where the selected agent's model is available, and that either `BEDROCK_API_KEY` or the `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` pair is valid. If you use IAM credentials, the principal must have permission to invoke the selected model. Codex requires access to the Bedrock Mantle path and an exact OpenAI Bedrock model ID such as `openai.gpt-5.6-terra`.

--- a/self-host/customize-deployment/environment-variables.mdx
+++ b/self-host/customize-deployment/environment-variables.mdx
@@ -670,6 +670,7 @@ Configure the sandboxed runtime that powers [data apps](/guides/data-apps/self-h
 | Variable                          | Description                                                                                                                                          |
 | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `APPS_RUNTIME_ENABLED`            | Enables the data apps runtime. (default=false)                                                                                                       |
+| `APPS_CODING_AGENT`               | Coding agent used to generate Data apps: `claude` (default) or `codex`. Codex uses `OPENAI_API_KEY` unless `AI_DEFAULT_PROVIDER=bedrock`.             |
 | `APP_RUNTIME_LIGHTDASH_ORIGIN`    | Origin the sandbox uses to call back into Lightdash. Defaults to `SITE_URL`.                                                                          |
 | `APP_RUNTIME_CDN_ORIGIN`          | Origin where built app bundles are served from (CDN in front of `APPS_S3_BUCKET`).                                                                    |
 | `APP_RUNTIME_PREVIEW_ORIGIN`      | Origin used to render app previews (typically a separate subdomain to isolate cookies).                                                                |
@@ -683,6 +684,8 @@ Configure the sandboxed runtime that powers [data apps](/guides/data-apps/self-h
 | `E2B_TEMPLATE_TAG`                | E2B template tag. Defaults to the running Lightdash version so the template matches the release.                                                      |
 | `E2B_AI_WRITEBACK_TEMPLATE_NAME`  | E2B template used for AI writeback sandboxes. (default=`lightdash-ai-writeback`)                                                                      |
 | `E2B_AI_WRITEBACK_TEMPLATE_TAG`   | E2B AI writeback template tag. Defaults to the running Lightdash version.                                                                             |
+
+`APPS_CODING_AGENT=codex` supports GPT-5.6 Sol, Terra, and Luna, with Terra as the default. When `AI_DEFAULT_PROVIDER=bedrock`, Lightdash runs those models through Amazon Bedrock instead of OpenAI directly. `AI_DEFAULT_PROVIDER` also controls AI Analyst; `APPS_CODING_AGENT` affects only Data apps.
 
 ## Managed agent
 

--- a/self-host/production-deployment-checklist.mdx
+++ b/self-host/production-deployment-checklist.mdx
@@ -358,6 +358,7 @@ Sandbox providers (E2B, AWS Lambda MicroVMs, Azure) and their security model are
 ```yaml
 configMap:
   APPS_RUNTIME_ENABLED: "true"
+  APPS_CODING_AGENT: claude        # claude (default) | codex
   SANDBOX_PROVIDER: e2b
   APP_RUNTIME_PREVIEW_ORIGIN: https://lightdash-apps.yourcompany.com   # separate origin!
 


### PR DESCRIPTION
## Summary

- document `APPS_CODING_AGENT` for self-hosted Data Apps
- add Codex setup through direct OpenAI access and Amazon Bedrock
- update the model/provider wording and deployment references

## Why

Self-hosted operators can now choose Codex instead of the default Claude coding agent. The docs currently describe Claude as mandatory.

## Impact

Self-hosters can configure Codex with an OpenAI API key or through Bedrock, see the available Codex model options, and understand that `AI_DEFAULT_PROVIDER` applies globally.

## Validation

- `node scripts/check-links.js`
- `node scripts/check-image-locations.js`
- code-fence balance check for the changed MDX files
- `git diff --check`

## Dependency

Depends on lightdash/lightdash#27435.