### PR TITLE
docs: cover the failed migration Job on Kubernetes

### DIFF
--- a/self-host/update-lightdash.mdx
+++ b/self-host/update-lightdash.mdx
@@ -71,6 +71,8 @@ helm upgrade -f values.yml lightdash lightdash/lightdash
 
 For a production deployment, follow the full sequence in the [upgrade runbook](/self-host/upgrade-runbook#kubernetes-and-helm): back up, check the span, upgrade, then watch migrations land.
 
+If the upgrade goes wrong, [recovery](/self-host/upgrade-runbook#recovery) covers reading a failed migration Job and running the `migrate` commands inside a pod to see what state the schema is actually in.
+
 ## Update the Lightdash CLI
 
 Your Lightdash CLI version should match the version of Lightdash you're running. After upgrading your deployment, make sure anyone using the CLI also upgrades it — otherwise commands like `lightdash preview` and `lightdash deploy` may behave unexpectedly.

--- a/self-host/upgrade-runbook.mdx
+++ b/self-host/upgrade-runbook.mdx
@@ -73,7 +73,7 @@ You do not need to change directory first. The image's working directory is `/us
 | `up` | Runs pending Knex and Graphile Worker migrations. This is the default when no command is given, and it is what the image entrypoint and the Helm migration Job run |
 | `preflight` | Checks migration safety **without changing the database**. Also runs automatically at the start of every `up` |
 | `status` | Prints the migration lease, the Knex ledger, and recent migration run history |
-| `wait` | Waits for another process to finish migrating, and takes over if that process died |
+| `wait` | Waits for migrations to finish. Follows a live migrator without racing it, and claims the lease itself if work is pending and no live holder exists |
 | `unlock` | Clears migration locks for recovery, with attribution |
 
 | Flag | Valid on | Meaning |
@@ -91,14 +91,20 @@ The commands need the deployment's database environment, so run them where that 
 
 <Tabs>
 <Tab title="kubectl exec">
-Against a running pod. Substitute your release name:
+Against a running pod:
 
 ```bash
-kubectl exec deploy/<release>-lightdash -- \
+kubectl exec deploy/lightdash-backend -- \
   pnpm -F backend migrate-production status
 ```
 
 `exec` bypasses the image entrypoint, so this inspects without triggering a migration.
+
+The examples on this page assume a release called `lightdash`, matching the `helm upgrade` command above. The chart names the backend Deployment `<fullname>-backend` and the migration Job `<fullname>-migrate`, where `<fullname>` is your release name when it already contains `lightdash`, and `<release>-lightdash` when it does not. `fullnameOverride` replaces it outright. If your release is named differently, list the real names:
+
+```bash
+kubectl get deploy,job -l app.kubernetes.io/instance=<release>
+```
 </Tab>
 <Tab title="One-off pod">
 To run the **new** image's preflight before you upgrade, run a Job on the new tag that reuses your backend's environment sources:
@@ -125,11 +131,12 @@ spec:
                   name: <your-database-secret>
                   key: <password-key>
           envFrom:
-            # the same ConfigMap and Secret your backend deployment uses
+            # the same ConfigMap and Secret your backend deployment uses,
+            # both named <fullname> by the chart
             - configMapRef:
-                name: <release>-lightdash
+                name: lightdash
             - secretRef:
-                name: <release>-lightdash
+                name: lightdash
 ```
 
 Read the result with `kubectl logs job/lightdash-preflight`.
@@ -193,9 +200,11 @@ Alongside the state it prints the lease holder (hostname, pod, app version, curr
 
 #### When you need `wait`
 
-`wait` blocks until the database is migrated, without racing anyone for the lease. If another process holds a live lease, `wait` follows it to the end. If that lease has expired, `wait` promotes itself and finishes the job. It gives up after 30 minutes by default; change that with `--timeout-ms` or `MIGRATION_WAIT_TIMEOUT_MS`.
+`wait` blocks until the database is migrated. While another process holds a live lease, it follows that process and never migrates alongside it. If migrations are still pending and the lease is unheld or has expired, `wait` claims the lease and runs them itself. It gives up after 30 minutes by default; change that with `--timeout-ms` or `MIGRATION_WAIT_TIMEOUT_MS`.
 
-You rarely need to run it by hand. On the non-Job path, `up` already falls back to this exact behaviour when it loses the race for the lease, which is how the pod that does not migrate ends up waiting for the pod that does. Reach for `wait` when you want a process to block on the schema being ready and never be the one to migrate it first.
+So `wait` is not a read-only command. It will not race a live migrator, but it will become the migrator when there is work to do and nobody is doing it. Use `status` when you only want to look.
+
+You rarely need to run `wait` by hand. On the non-Job path, `up` already falls back to this exact behaviour when it loses the race for the lease, which is how the pod that does not migrate ends up waiting for the pod that does.
 
 ## Kubernetes and Helm
 
@@ -237,8 +246,8 @@ With `migrationJob.enabled: true`, the chart runs migrations in a `pre-install,p
 Follow the migration:
 
 ```bash
-kubectl logs -f job/<release>-lightdash-migrate     # when migrationJob is enabled
-kubectl exec deploy/<release>-lightdash -- \
+kubectl logs -f job/lightdash-migrate     # when migrationJob is enabled
+kubectl exec deploy/lightdash-backend -- \
   pnpm -F backend migrate-production status
 ```
 
@@ -355,8 +364,8 @@ If verification fails, freeze: open a freeze issue, escalate to the channel, and
 On the `migrationJob.enabled` path, a failed upgrade shows up as a failed Job. Read its logs before you reach for anything else. The migration's own error says what broke; the commands below only tell you the state it left behind.
 
 ```bash
-kubectl logs job/<release>-lightdash-migrate
-kubectl describe job/<release>-lightdash-migrate
+kubectl logs job/lightdash-migrate
+kubectl describe job/lightdash-migrate
 ```
 
 The Job retries before it gives up. `migrationJob.backoffLimit` defaults to `10`, so Kubernetes marks the Job failed only after 11 attempts. Each attempt runs in its own pod, so `kubectl logs job/...` shows you one of them and `kubectl get pods` shows the rest.
@@ -374,7 +383,7 @@ To retry after you have fixed the cause, re-run `helm upgrade` to recreate the h
 Start by looking, not by fixing:
 
 ```bash
-kubectl exec deploy/<release>-lightdash -- \
+kubectl exec deploy/lightdash-backend -- \
   pnpm -F backend migrate-production status
 ```
 
@@ -389,7 +398,7 @@ Do **not** edit the `knex_migrations_lock` table by hand on `1.123.0` and later.
 ### Releasing a lock
 
 ```bash
-kubectl exec deploy/<release>-lightdash -- \
+kubectl exec deploy/lightdash-backend -- \
   pnpm -F backend migrate-production unlock --actor "alex@example.com"
 ```
 

--- a/self-host/upgrade-runbook.mdx
+++ b/self-host/upgrade-runbook.mdx
@@ -60,11 +60,13 @@ Exit `0` means the whole span is proven safe to roll. Anything else, including a
 
 ### The `migrate` commands
 
-These ship inside the Lightdash image and are the runtime execution layer. Invoke them the same way the image's own entrypoint does, from the `/usr/app` working directory:
+These ship inside the Lightdash image and are the runtime execution layer. Invoke them the same way the image's own entrypoint does:
 
 ```bash
 pnpm -F backend migrate-production <command> [flags]
 ```
+
+You do not need to change directory first. The image's working directory is `/usr/app/packages/backend`, which is where the entrypoint runs this command, and both `kubectl exec` and `docker compose exec` inherit it. The chart's migration Job runs the same command from `/usr/app` instead. Either directory works.
 
 | Command | What it does |
 | --- | --- |
@@ -182,12 +184,18 @@ The decision is one of `proceed`, `proceed-with-warnings`, `abort`, or `force-pr
 | --- | --- |
 | `idle` | Nobody holds the lease and nothing is parked |
 | `migrating` | A process holds the lease and is heartbeating |
-| `stale` | A process holds the lease but its heartbeat has expired. Another process will take over |
+| `stale` | A process holds the lease but its heartbeat has expired, 75 seconds after the last one. Another process will take over |
 | `parked` | Migration failed its retries and stopped. It will not retry on this app version until a human intervenes |
 
 Alongside the state it prints the lease holder (hostname, pod, app version, current migration, last heartbeat), the parked details if any, the completed and pending Knex migration counts, the ledger classification, and recent migration runs with their outcomes. Any prior `unlock` is recorded against the run that followed it, so the audit trail survives.
 
 `--json` gives you the same payload for automation.
+
+#### When you need `wait`
+
+`wait` blocks until the database is migrated, without racing anyone for the lease. If another process holds a live lease, `wait` follows it to the end. If that lease has expired, `wait` promotes itself and finishes the job. It gives up after 30 minutes by default; change that with `--timeout-ms` or `MIGRATION_WAIT_TIMEOUT_MS`.
+
+You rarely need to run it by hand. On the non-Job path, `up` already falls back to this exact behaviour when it loses the race for the lease, which is how the pod that does not migrate ends up waiting for the pod that does. Reach for `wait` when you want a process to block on the schema being ready and never be the one to migrate it first.
 
 ## Kubernetes and Helm
 
@@ -342,6 +350,25 @@ If verification fails, freeze: open a freeze issue, escalate to the channel, and
 
 ## Recovery
 
+### The migration Job failed
+
+On the `migrationJob.enabled` path, a failed upgrade shows up as a failed Job. Read its logs before you reach for anything else. The migration's own error says what broke; the commands below only tell you the state it left behind.
+
+```bash
+kubectl logs job/<release>-lightdash-migrate
+kubectl describe job/<release>-lightdash-migrate
+```
+
+The Job retries before it gives up. `migrationJob.backoffLimit` defaults to `10`, so Kubernetes marks the Job failed only after 11 attempts. Each attempt runs in its own pod, so `kubectl logs job/...` shows you one of them and `kubectl get pods` shows the rest.
+
+<Warning>
+**Those logs delete themselves.** `migrationJob.ttlSecondsAfterFinished` defaults to `100`, so Kubernetes removes the Job about 100 seconds after it finishes — failed or succeeded — and the pod logs go with it. If you are debugging upgrades, raise that value in your values file, or ship the Job's logs off the cluster before the window closes.
+</Warning>
+
+If you missed the window, the database still has the durable record. `migrate status` reports the parked details and recent migration runs with their outcomes, and that record outlives the Job object.
+
+To retry after you have fixed the cause, re-run `helm upgrade` to recreate the hook Job. See [what resumes on its own](#after-an-unlock-what-resumes-on-its-own).
+
 ### A migration is stuck
 
 Start by looking, not by fixing:
@@ -352,7 +379,7 @@ kubectl exec deploy/<release>-lightdash -- \
 ```
 
 - **`migrating`** with a recent heartbeat: it is working. Migrations on large tables can take a long time. Leave it alone.
-- **`stale`**: the holder died. Another process takes the lease over automatically once it expires. No action needed in most cases.
+- **`stale`**: the holder died. The lease expires 75 seconds after its last heartbeat, and another process takes it over automatically. No action needed in most cases.
 - **`parked`**: the migration failed its retries (three attempts with backoff) and stopped deliberately. The same app version will refuse to retry, which is what stops a crash-looping pod from hammering a half-applied migration. Fix the cause, then deploy a fixed version, or unlock with attribution and retry.
 
 <Warning>


### PR DESCRIPTION
## The gap

The brief for this was "nothing tells a Kubernetes operator how to run `migrate status` / `preflight` / `unlock`". That turned out not to be true. `self-host/upgrade-runbook.mdx` already documents all five verbs, the `kubectl exec` pattern, the one-off Job, the preflight check table and the `unlock` warnings. A grep for `migrate status` misses it because the page writes the commands as `pnpm -F backend migrate-production status`.

So this PR does not add a second page on the same commands. It fixes errors in that page and fills the parts that were genuinely missing for an operator whose upgrade has just failed.

## What changed

### New content

- **New recovery section, "The migration Job failed"**. Read `kubectl logs job/lightdash-migrate` first, because the migration's own error is more useful than the state it left behind. Covers the `backoffLimit` default of `10`, that each attempt is its own pod, and the retry path.
- **A warning that those logs delete themselves.** `migrationJob.ttlSecondsAfterFinished` defaults to `100`, so Kubernetes removes the Job about 100 seconds after it finishes, failed or succeeded, and takes the pod logs with it. Nothing in the docs said this. It is the most likely way an operator loses the evidence for a failed upgrade.
- **A section on what `wait` does and when you need it**, which previously had only a one-line table entry.
- The `stale` state now names the number that makes it stale: the lease expires **75 seconds** after its last heartbeat.

### Corrections to existing text

- **`migrate wait` is not read-only.** `followMigrations` treats an unheld lease as claimable, so `wait` claims it and runs the migrations itself when work is pending and nobody holds the lease. It only declines to migrate alongside a *live* holder. The first draft of this PR said the opposite; it is now correct in both the prose and the command table.
- **Every `kubectl` resource name on the page was wrong.** The chart names the backend Deployment `<fullname>-backend` and the migration Job `<fullname>-migrate`, and `lightdash.fullname` collapses to the release name when it already contains `lightdash`. For the release this page documents, that is `deploy/lightdash-backend` and `job/lightdash-migrate`. The old `deploy/<release>-lightdash` matched no object in any configuration — it was missing the `-backend` suffix entirely. The ConfigMap and Secret in the one-off Job example were wrong the same way. The page now states the naming rule and gives `kubectl get deploy,job -l app.kubernetes.io/instance=<release>` for anyone on a different release name.
- **The working directory.** The page said to run the commands "from the `/usr/app` working directory, the same way the image's own entrypoint does". The entrypoint does not run from there. The image's final `WORKDIR` is `/usr/app/packages/backend` and that is where `docker/prod-entrypoint.sh` runs `pnpm -F backend migrate-production up`. `/usr/app` is what the chart's migration Job sets. Both work, and `kubectl exec` inherits the image directory, so the page now says you need not change directory at all.

`self-host/update-lightdash.mdx` — the Kubernetes section now links to recovery, not just the happy-path sequence.

## Verification

Every claim was checked against source and against a real container, by a second agent running an adversarial fact-check. Its first verdict was "not safe to merge"; the two blocking findings are the `wait` behaviour and the resource names, both fixed above and both re-confirmed by hand before the fix landed.

| Claim | Evidence |
| --- | --- |
| Image `WORKDIR` is `/usr/app/packages/backend` | `dockerfile:446`; `docker inspect` on the published image agrees |
| Entrypoint runs `migrate-production up` from there, no `cd` | `docker/prod-entrypoint.sh:6` |
| The command works from **both** `/usr/app` and `/usr/app/packages/backend` | Run in the published image `lightdash/lightdash@sha256:f9c4fce4…` (`1.191.2`). Both exited `0` and printed the migrate usage text |
| `kubectl exec` inherits the image working directory | OCI image config + containerd exec reuses the process spec Cwd; chart sets no `workingDir` on the backend container. `docker exec … pwd` returned `/usr/app/packages/backend` |
| Job uses `workingDir: /usr/app` and the four-token command | `templates/migrationJob.yaml:44-49` |
| `backoffLimit: 10`, `ttlSecondsAfterFinished: 100` | `values.yaml:331` |
| TTL deletes **failed** Jobs too, cascading to pods | Kubernetes TTL-after-finished docs: eligible on `Complete` *or* `Failed`, timer starts at that condition, deletion is cascading. Helm's `before-hook-creation` policy does not delete it sooner |
| `backoffLimit: 10` means 11 pod attempts | Job controller fails when `failed > backoffLimit`, with `restartPolicy: Never` |
| Resource names | `_helpers.tpl:13` (`lightdash.fullname`), `backendDeployment.yaml:6`, `migrationJob.yaml:5`, `configmap.yaml:5`, `secrets.yaml:5` |
| Lease expiry 75s, measured from last heartbeat not claim time | `migrationLease.ts:10`, and the comparisons at lines 313-324 / 653-660 |
| `wait` claims an unheld lease | `cli.ts:852` — `claimable = !active \|\| lease?.expired === true`, then claim and `runAsHolder` |
| `up` follows when it loses the race | `runUp` → same `followMigrations` path, `cli.ts:893` |
| Verbs and flags match the CLI | `MIGRATE_CLI_HELP` in `cli.ts:34`; the real image's `--help` matched |
| `/usr/app/release-safety.json` is baked in | Present in the public image, 873 bytes — so preflight works air-gapped |

`node scripts/check-links.js` passes.

## Deliberately left out

- **"The Job becomes the default migrator in chart 3.0.0."** The chart is at `2.11.0` with `migrationJob.enabled: false`. Could not verify, so it is not in the docs.
- **"The entrypoint uses `wait` for non-Job deployments."** It does not. It runs `up`, and `up` falls back to the follower path when it loses the race for the lease.
- No sample CLI output was invented.

## Found but not fixed here

Pre-existing issues outside this change, surfaced by the fact-check and worth separate tickets:

1. `docker pull lightdash/lightdash` fails on Apple Silicon — the image is published `linux/amd64` only, so the local-deployment instructions need `--platform linux/amd64` or a multi-arch image.
2. The claim that backend pods migrate at startup "without `migrationJob`" is true for the defaults but ignores `image.command`, which takes precedence over that branch.
3. `update-lightdash.mdx` says minor versions "introduce new features or bigger changes that are backwards incompatible", which contradicts SemVer. That reads like a deliberate statement of Lightdash's own policy, so it needs a product decision rather than a docs edit.

Linear: SPK-1083
