### PR TITLE
docs: document chart slug renaming

### DIFF
--- a/guides/developer/dashboards-as-code.mdx
+++ b/guides/developer/dashboards-as-code.mdx
@@ -294,6 +294,65 @@ For example:
 - Priyanka makes changes to `total-new-clients.yml` then runs `lightdash upload` and uploads her changes and overwrites the changes that Jake made in the Lightdash application.
 - Both Jake and Priyanka can update the same chart as code, or in the Lightdash application.
 
+## Rename a chart slug
+
+Use `lightdash slug-update` when you want to change a chart's URL slug without creating a new chart or breaking existing links:
+
+```bash
+lightdash slug-update --from copy-of-total-orders --to total-orders
+```
+
+The command performs both sides of the rename:
+
+1. It renames the chart in Lightdash and keeps the previous slug as an alias.
+2. It updates the chart file and every supported reference in your local content-as-code directory.
+
+Local updates include dashboard chart tiles, scheduled deliveries, alerts, Google Sheets syncs, language maps, filenames, and content metadata. The output lists each file that changed, including filename moves such as:
+
+```text
+charts/copy-of-total-orders.yml -> charts/total-orders.yml
+dashboards/executive-overview.yml
+```
+
+You do not need to upload after a successful rename: Lightdash and your local files are already synchronized. For a Git-managed workflow, review the changes and commit them in the same pull request as any related content updates.
+
+Preview the local changes before applying the rename with `--dry-run`:
+
+```bash
+lightdash slug-update \
+  --dry-run \
+  --from copy-of-total-orders \
+  --to total-orders
+```
+
+<Warning>
+The dry run does not validate whether the server-side target slug is available. The real command performs permission, alias, and uniqueness checks before changing any local files.
+</Warning>
+
+### How aliases protect existing content
+
+When a chart changes from `copy-of-total-orders` to `total-orders`, Lightdash keeps `copy-of-total-orders` as an alias for the same chart. This means:
+
+- bookmarks, shared links, and CI-generated URLs using the old slug still work;
+- a stale branch or checkout that uploads the old slug updates the existing chart instead of creating a duplicate;
+- re-running the same rename is a safe no-op;
+- you can rename the chart back to a previous slug without losing the newer slug—it becomes the alias instead.
+
+If the API rename succeeds but the CLI cannot write the local files, the command reports that Lightdash was updated. Fix the local filesystem issue and run the same command again; the server-side rename is idempotent and the CLI will finish updating the local files.
+
+Use `--path <path>` when your content-as-code files are not in the default `lightdash/` directory:
+
+```bash
+lightdash slug-update \
+  --from copy-of-total-orders \
+  --to total-orders \
+  --path ./analytics-content
+```
+
+<Note>
+Slug renaming currently supports regular charts only. SQL chart, dashboard, space, and data app slugs are not renamed by this command.
+</Note>
+
 ## Lightdash content templates
 
 You can use the `lightdash download` and `lightdash upload` commands to easily build templates for Lightdash content and reuse these templates to build new or update existing projects.

--- a/references/lightdash-cli.mdx
+++ b/references/lightdash-cli.mdx
@@ -11,6 +11,7 @@ keywords:
   - lightdash preview
   - lightdash validate
   - lightdash dbt run
+  - lightdash slug-update
   - lightdash warehouse-catalog
   - CLI commands
 ---
@@ -132,6 +133,7 @@ For examples and command-specific options, click through the command in the tabl
 |[`lightdash generate-exposures`](/references/lightdash-cli#lightdash-generate-exposures) | [Experimental command] Generates a YAML file for Lightdash exposures               |
 |[`lightdash download`](/references/lightdash-cli#lightdash-download)                     | Download all charts and dashboards from your Lightdash project as code             |
 |[`lightdash upload`](/references/lightdash-cli#lightdash-upload)                         | Upload charts and dashboards as code to your Lightdash project                     |
+|[`lightdash slug-update`](/references/lightdash-cli#lightdash-slug-update)               | Rename a chart slug and update its local content-as-code references                 |
 |[`lightdash apps create`](/references/lightdash-cli#lightdash-apps-create)               | Scaffold a new [data app](/guides/data-apps/building-locally) locally               |
 |[`lightdash apps preview`](/references/lightdash-cli#lightdash-apps-preview)             | Preview a downloaded [data app](/guides/data-apps/building-locally) locally against real data |
 |[`lightdash apps validate`](/references/lightdash-cli#lightdash-apps-validate)           | Validate a [data app](/guides/data-apps/building-locally) locally before uploading |
@@ -1098,6 +1100,70 @@ Upload organization resources and also send invitation emails to any staged user
 ```bash
 lightdash upload --organization --send-invites
 ```
+
+
+### `lightdash slug-update`
+
+Renames a chart slug in Lightdash and updates the corresponding files in your local content-as-code directory.
+
+```bash
+lightdash slug-update --from old-chart-slug --to new-chart-slug
+```
+
+A successful rename:
+
+- changes the chart's canonical slug and URL in Lightdash;
+- keeps the previous slug as an alias, so existing links continue working;
+- updates the chart YAML slug and filename;
+- updates saved-chart references in dashboard YAML;
+- updates chart references in scheduled deliveries, alerts, and Google Sheets syncs;
+- updates chart language-map files and `.lightdash-metadata.json`, when present.
+
+You do not need to run `lightdash upload` afterward. The command updates Lightdash first and then updates the local files. If you keep content in Git, review and commit the resulting file changes.
+
+<Note>
+The command currently supports regular charts only. It does not rename SQL chart, dashboard, space, or data app slugs. Dashboard tile slugs are also left unchanged because they identify the tile, not the chart.
+</Note>
+
+**Options:**
+
+- `--from <slug>`
+  - required; the chart's current canonical slug, or its previous slug when safely retrying the same rename.
+- `--to <slug>`
+  - required; the new slug. Slugs contain lowercase letters, numbers, and hyphen-separated words.
+- `--path <path>`
+  - use a custom content-as-code directory instead of the default `lightdash/` directory in your current working directory.
+- `--project <project uuid>`
+  - rename the chart in a specific project instead of your currently selected project.
+- `--dry-run`
+  - preview the intended slug change and list the local files that would change without renaming the chart or writing files.
+- `--verbose`
+  - show detailed command output.
+
+<Warning>
+`--dry-run` validates and previews local file changes only. Lightdash checks the source chart, permissions, aliases, and target-slug availability when you run the command without `--dry-run`.
+</Warning>
+
+**Examples:**
+
+Preview a rename and its local file changes:
+
+```bash
+lightdash slug-update --dry-run --from copy-of-orders --to orders
+```
+
+Rename a chart and update a custom content-as-code directory:
+
+```bash
+lightdash slug-update \
+  --from copy-of-orders \
+  --to orders \
+  --path ./analytics-content
+```
+
+The command is idempotent. Re-running the same rename safely completes any missing local updates. You can also rename a chart back to one of its previous slugs; the slug you replace becomes the new alias.
+
+Aliases reserve their slugs within the project. Creating or uploading another chart with a current or historical slug uses the existing chart or generates a different unique slug instead of creating an ambiguous duplicate.
 
 
 ### `lightdash apps create`


### PR DESCRIPTION
## Summary

- add `lightdash slug-update` to the CLI command reference, including its options and examples
- document chart slug aliases, idempotent retries, reverting to a previous slug, and duplicate protection
- explain which local content-as-code references are updated and why no upload is required afterward
- clarify that `--dry-run` previews local changes but defers server-side validation until the real rename

## Validation

- `node scripts/check-links.js`
- `node scripts/check-image-locations.js`
- `git diff --check`

Relates: SPK-736
Relates: lightdash/lightdash#14578
