### PR TITLE
docs: multiple roles (role sets) — custom roles, SCIM, users as code

### DIFF
--- a/guides/developer/dashboards-as-code.mdx
+++ b/guides/developer/dashboards-as-code.mdx
@@ -1248,6 +1248,25 @@ role:
 | `disabled` | `true` to deactivate the member, `false` to keep them active. Uploads never disable the last enabled authenticated admin. |
 | `role.type` | Either `system` or `custom`. `system` uses one of the built-in roles (`member`, `viewer`, `interactive_viewer`, `editor`, `developer`, `admin`); `custom` references a user-defined role. |
 | `role.name` | For `system`, the built-in role name. For `custom`, the exact organization-level custom role name — the referenced role must exist (or be created in the same upload's custom-roles phase). |
+| `additionalRoles` | Optional. Extra organization-level **custom** roles held on top of `role`, when [multiple roles](/references/workspace/custom-roles#assigning-multiple-roles-role-sets) are enabled. Each entry is `{ type: custom, name: <role name> }`. Omitted on download when the user holds a single role. |
+
+When multiple roles are enabled, a member with a system role plus extra custom roles serializes as:
+
+```yaml
+version: 1
+email: sam@ecom-store.com
+disabled: false
+role:
+  type: system
+  name: viewer
+additionalRoles:
+  - type: custom
+    name: roadmap-viewer
+  - type: custom
+    name: sql-runner
+```
+
+The file describes the member's **complete** organization role set: uploading a file without `additionalRoles` for a member who currently holds extra roles removes those extras. Uploads that contain `additionalRoles` require multiple roles to be enabled for the organization (the file fails with `403` otherwise), and instances that do not support the field reject it rather than silently dropping it.
 
 Lifecycle status (whether a user has authenticated yet, whether they have a valid invitation) is **derived from the destination user during upload** and is not declared in YAML. Legacy fields such as `pending` are rejected.
 

--- a/references/workspace/custom-roles.mdx
+++ b/references/workspace/custom-roles.mdx
@@ -48,6 +48,10 @@ Organization-level custom role -> organization-only scopes + project scopes
   **Custom roles can only add permissions, not remove them.** Lightdash uses an additive permission model. If a user already has a permission granted through their organization-level role, a custom project role cannot take it away. Toggling off a scope in a custom role has no effect for users who already have that scope from their org role.
 </Warning>
 
+<Info>
+  Enterprise organizations can also hold **more than one role at the same level** — a system role plus one or more custom roles, or several custom roles — as a single *role set*. See [Assigning multiple roles](#assigning-multiple-roles-role-sets) below.
+</Info>
+
 ### How additive permissions work
 
 Custom roles operate at the **project level** and can only grant additional permissions on top of what the user's organization role already provides. They cannot restrict or override org-level permissions.
@@ -139,6 +143,94 @@ Custom roles are assigned at the project level to provide granular access contro
 2. Find the group you want to assign a role to
 3. Select the custom role from the dropdown
 4. All members of the group will inherit the custom role permissions for this project
+
+## Assigning multiple roles (role sets)
+
+By default every user or group holds **one** role per level: one organization role, and at most one role per project. Enterprise organizations can ask Lightdash to enable **multiple roles**, which turns each of those single roles into a **role set**:
+
+- **at most one system role** — the base (`viewer`, `editor`, `admin`, …), or none;
+- **any number of custom roles** of the matching level (organization or project), added on top.
+
+Permissions are the **union** of every role in the set. Identical roles are de-duplicated, and a set can never be empty.
+
+```
+Organization role set: [ Viewer ] + [ Roadmap viewer ] + [ SQL runner ]
+Project role set:      [ Editor ] + [ Finance exports ]
+Restrictive set:                     [ Report reader ]        (custom only, no base)
+```
+
+Because permissions only add up, a system base is never narrowed by the custom roles next to it. To build a *restrictive* profile, leave the system role out and use a custom-only set (the same "start from Viewer or Member" approach described in [Restricting permissions with custom roles](#restricting-permissions-with-custom-roles)).
+
+### Eligibility
+
+Multiple roles require:
+
+- a Lightdash **Enterprise** plan with custom roles;
+- the **multiple roles** feature enabled for your organization — contact your Lightdash account team to switch it on.
+
+Until it is enabled, the role pickers, API endpoints and provisioning integrations behave exactly as before, with one role per level. Any extra roles that were assigned while the feature was on stay effective if it is later switched off — only the ability to *manage* sets is gated.
+
+### In the UI
+
+Once enabled, the single role dropdown becomes a role picker on:
+
+- **Settings → Users & groups → Users** — the organization role set of each member;
+- **Project settings → Project access → Users** — a member's direct project role set;
+- **Project settings → Project access → Groups** — a group's project role set.
+
+The picker shows one pill per role. Choosing a system role replaces the current system role; choosing a custom role adds it. Removing the last pill is not allowed — use the remove-access action to drop direct access instead. Rows that inherit their access ("Inherits Editor", "No project access") work as before: picking a role creates a direct assignment.
+
+Invitations and the "add access" dialogs still assign a single role; add more roles from the table afterwards.
+
+### Via the API
+
+Three `v2` endpoints read and replace a whole set atomically. They return `403` when multiple roles are not enabled for the organization.
+
+| Level | Endpoint |
+| --- | --- |
+| Organization member | `GET` / `PUT /api/v2/orgs/{orgUuid}/roles/assignments/user/{userUuid}/set` |
+| Project member | `GET` / `PUT /api/v2/projects/{projectUuid}/roles/assignments/user/{userUuid}/set` |
+| Project group | `GET` / `PUT /api/v2/projects/{projectUuid}/roles/assignments/group/{groupUuid}/set` |
+
+The body and the response share one shape — `systemRole` is a system role name or `null`, `customRoleUuids` lists custom roles of the matching level:
+
+```bash
+curl -X PUT \
+  -H "Authorization: ApiKey $LIGHTDASH_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$LIGHTDASH_URL/api/v2/projects/3675b69e-8324-4110-bdca-059031aa8da3/roles/assignments/user/e0dd2003-c291-4e14-b977-7a03b7edc842/set" \
+  -d '{
+    "systemRole": "editor",
+    "customRoleUuids": ["11df7b19-1db7-44f3-aa48-54f8bbd6c89a"]
+  }'
+```
+
+```json
+{
+  "status": "ok",
+  "results": {
+    "systemRole": "editor",
+    "customRoleUuids": ["11df7b19-1db7-44f3-aa48-54f8bbd6c89a"]
+  }
+}
+```
+
+A `PUT` **replaces** the whole set: roles you leave out are removed. Requests are rejected with `400` when the set is empty or contains a role of the wrong level, and with `403` when a role belongs to another organization, when the caller could not grant one of the requested roles themselves, or when the change would leave the organization without an active admin.
+
+The existing single-role endpoints keep working. Their responses report the **primary** role of the set (the system role, or the first custom role when there is no system role) plus a `hasMultipleRoles: true` flag when the assignment holds more roles, and a **single-role write replaces the whole set** with that one role — so an older client or script that assigns a role clears any extras. Use the `…/set` endpoints from clients that need to keep sets intact.
+
+### SCIM and users as code
+
+- **SCIM** represents every role in a set as one entry of the standard `roles` array — see [User Role Provisioning](/references/workspace/scim-integration#user-role-provisioning).
+- **Users as code** carries extra organization custom roles in an `additionalRoles` list — see [Users as code](/guides/developer/dashboards-as-code#users-as-code).
+
+### Troubleshooting multiple roles
+
+- **`403 Multiple roles are not enabled`** on the `…/set` endpoints — the feature is not switched on for the organization; single-role behaviour applies.
+- **`400 A role set must contain at least one role`** — send at least one system or custom role, or use the remove-access endpoint / trash action to drop the assignment.
+- **A user lost their extra roles** — a single-role write (an older client, script, or IdP payload) replaced the set. Re-assign the extras with the picker or the `…/set` endpoint.
+- **A custom role in the set does not seem to restrict anything** — sets are additive; check whether a system role sits in the same set or at the organization level. See [How additive permissions work](#how-additive-permissions-work).
+- **Changes not visible yet** — the affected user may need to refresh; permissions rebuild on their next request.
 
 ## Scope reference
 

--- a/references/workspace/scim-integration.mdx
+++ b/references/workspace/scim-integration.mdx
@@ -297,7 +297,7 @@ You can find the full API docs and examples for SCIM [here](https://docs.lightda
 - `userName` is mapped to the user's primary email in Lightdash. Make sure your identity provider sets `userName` to the user's primary email (and, if sending an `emails` array, the primary email should match).
 - When a user is updated to be inactive (`active: false`) via SCIM, Lightdash will mark the user as inactive, lower their organization role to `member`, and remove their access from all projects and groups. If you later reactivate the user, you'll need to re-assign their group and project access via SCIM or in Lightdash.
 - An organization must always have at least one `admin`. Any SCIM request that would leave the organization with no admins (for example, demoting or deactivating the sole remaining admin) will be rejected with an error.
-- A user can only have one role per organization and per project.
+- A user can only have one role per organization and per project, unless [multiple roles](/references/workspace/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization — see [Provisioning role sets](#provisioning-role-sets) below.
 - A user must have an organization role.
 - On creation, if no `roles` are provided, the organization role will default to `member`.
 - On edit (PUT/PATCH), if no `roles` are provided, no changes are made to the user's roles.
@@ -399,6 +399,34 @@ Examples:
     },
 ]
 ```
+
+### Provisioning role sets
+
+When [multiple roles](/references/workspace/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization, the same `roles` array can carry a complete **role set** per level: at most one system role plus any number of custom roles for the organization, and likewise per project. No Lightdash-specific schema extension is needed.
+
+**Reading.** `GET /Users` and `GET /Users/{id}` list every role the user holds. The organization's system role (or its only custom role) is marked `"primary": true`; every additional role is `"primary": false`.
+
+```json
+"roles": [
+  { "value": "viewer", "display": "Viewer", "type": "Organization", "primary": true },
+  { "value": "6aa57126-fc60-42c3-9d83-495c40ae4ec3", "display": "Roadmap viewer", "type": "Organization", "primary": false },
+  { "value": "3675b69e-8324-4110-bdca-059031aa8da3:editor", "display": "Jaffle shop - Editor", "type": "Project - Jaffle shop", "primary": false },
+  { "value": "3675b69e-8324-4110-bdca-059031aa8da3:11df7b19-1db7-44f3-aa48-54f8bbd6c89a", "display": "Jaffle shop - SQL runner", "type": "Project - Jaffle shop", "primary": false }
+]
+```
+
+**Writing.** SCIM owns the complete direct role set of the users it manages:
+
+- `PUT` and `PATCH` `replace` on `roles` set the **exact** set: roles that are omitted are removed, and — as before — a project with no entry in the payload loses the user's direct access (`<project_uuid>:no-role` still works for explicit removal).
+- `PATCH` `add` unions the named roles into the existing set; `PATCH` `remove` takes the named roles out.
+- Identical entries are de-duplicated. A payload with no organization entry, more than one system organization role, or more than one system role for the same project is rejected with `400`.
+- Deactivating a user (`active: false`) still clears their roles as described above.
+
+While the feature is disabled, a `roles` array with more than one entry per level is rejected exactly as before, so existing IdP mappings do not change behaviour until you opt in.
+
+<Warning>
+  A payload with a **single** role per level (the legacy shape) replaces the whole set with that one role. If your IdP is the source of truth, make sure every role a user should keep is present in its `roles` mapping before enabling multiple roles.
+</Warning>
 
 ### Configuring available roles in your Identity Provider (IdP)
 


### PR DESCRIPTION
Closes PROD-10221

Documents the shipped multiple-roles feature (lightdash/lightdash #27500 #27502 #27503 #27515 #27516 #27519 #27569).

## Changes

**`references/workspace/custom-roles.mdx`** — new section *Assigning multiple roles (role sets)*:
- model: at most one system (base) role + any number of custom roles, permissions = union, sets never empty, base never narrowed (restriction = custom-only set)
- eligibility (Enterprise + custom roles + feature enabled by Lightdash) and what changes / doesn't change while it's off
- the three UI surfaces (org users, project users, project groups) and picker behaviour
- the `v2 …/set` endpoints with a `curl` example, error codes, and how the legacy single-role endpoints behave (`hasMultipleRoles`, single-role write replaces the whole set)
- troubleshooting

**`references/workspace/scim-integration.mdx`** — *Provisioning role sets*: read shape (`primary: true/false`), PUT/PATCH replace = exact set, add = union, remove = diff, validation rules, and a warning that legacy single-role payloads collapse a set.

**`guides/developer/dashboards-as-code.mdx`** — users as code: `additionalRoles` field, YAML example, complete-set semantics, requires feature enabled / rejected by older instances.

The `AGENTS.md` correction the ticket mentions is a separate lightdash PR: lightdash/lightdash#27610. The API reference picks the new endpoints up from `main`'s swagger automatically.

## Checks
- `node scripts/check-links.js` ✅ · `node scripts/check-image-locations.js` ✅
- Every behavioural claim was checked against the shipped code (status codes, SCIM omitted-project semantics, users-as-code complete-set replace, flag gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)