### PR TITLE
docs: say which health endpoint belongs on which probe

### DIFF
--- a/self-host/production-deployment-checklist.mdx
+++ b/self-host/production-deployment-checklist.mdx
@@ -48,6 +48,7 @@ None of these steps are required but are recommended for running Lightdash beyon
 - [NATS \+ warehouse workers](/self-host/nats-workers/overview) - `nats.enabled: true` **and** `warehouseNatsWorker.enabled: true` for handling large volumes of warehouse queries
 - [≥ 2 backend replicas](#sizing-and-availability) with pod anti-affinity and a pod disruption budget
 - [Size resource requests](#sizing-and-availability)
+- [Configure health probes](#health-probes) - readiness on `/api/v1/readyz`, not `/api/v1/health`, so a migrating pod leaves the load balancer without being restarted
 
 ### Infrastructure dependencies
 
@@ -221,6 +222,34 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 1
 ```
+
+## Health probes
+
+Lightdash serves three health endpoints, and they are not interchangeable:
+
+| Probe | Endpoint | Why |
+| --- | --- | --- |
+| Liveness | `/api/v1/livez` | Answers without touching the database, so a database blip does not restart every pod at once |
+| Readiness | `/api/v1/readyz` | TTL-cached, gates on schema migration state. Keeps a pod out of the load balancer while it is migrating, without restarting it |
+| Startup | `/api/v1/livez` | Same endpoint as liveness, so a slow-starting pod is not killed before it is ready to serve |
+
+Avoid `/api/v1/health` for any of the three. It queries the database on every request, which is fine for a manual `curl` after a deploy but means a brief database blip fails every pod's check at the same time.
+
+The chart already points `startupProbe` and `livenessProbe` at `/api/v1/livez` by default. Set the readiness path explicitly:
+
+```yaml
+lightdashBackend:
+  readinessProbe:
+    path: /api/v1/readyz
+```
+
+Recent chart versions resolve this path for you on Lightdash `1.169.1` and later. Setting it explicitly is always supported, and an explicit value always wins.
+
+<Warning>
+Only point a readiness probe at `/api/v1/readyz` on Lightdash `1.169.1` or later. Before that, a parked migration marked every working pod as not ready, so a readiness probe on `/api/v1/readyz` could pull the whole backend out of service over a single stuck migration. See [what shipped when](/self-host/upgrade-runbook#what-shipped-when) and the [upgrade runbook](/self-host/upgrade-runbook#kubernetes-and-helm) for the full reasoning and the `503` reasons.
+</Warning>
+
+Leave worker probes alone. Worker pods serve their own handler at `/api/v1/health` (in-memory state, no database query) and do not serve `/api/v1/readyz` at all.
 
 ## PostgreSQL
 

--- a/self-host/upgrade-runbook.mdx
+++ b/self-host/upgrade-runbook.mdx
@@ -38,6 +38,11 @@ Every command on this page is in a released image. Version-fence your runbook ac
 | `migrate preflight` | Lightdash `1.125.0` |
 | `lightdash upgrade-check` | Lightdash CLI `1.126.0` |
 | `/api/v1/livez` and `/api/v1/readyz` probes | Lightdash `1.129.0` |
+| `/api/v1/readyz` keeps working pods in service during a parked migration | Lightdash `1.169.1` |
+
+<Warning>
+On Lightdash `1.129.0` to `1.168.x`, do not point a readiness probe at `/api/v1/readyz`. A parked migration marked every working pod as not ready, so a single stuck migration removed the whole backend from the load balancer. Fixed in `1.169.1`. See [configuring health probes](/self-host/production-deployment-checklist#health-probes) for the current setup.
+</Warning>
 
 If you are upgrading *from* something older, that is fine. These are properties of the image you are upgrading *to*, and of the CLI you run the check with. The one place the old world still shows up is [rolling back across the `1.123.0` boundary](#rolling-back).
 
@@ -258,6 +263,8 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://lightdash.example.com/api/v1/r
 ```
 
 A `503` carries a `reason`: `schema_pending` (migrations still outstanding), `migration_parked` (a migration failed and stopped), `migration_ledger_unavailable`, or `db_unavailable`. `/api/v1/livez` answers without touching the database, which is why it is the right liveness probe and the wrong readiness signal.
+
+`/api/v1/health` also answers, but it queries the database on every call. That makes it a fine manual check to run after a deploy, and a poor probe, since a brief database blip fails it on every pod at once. Worker pods serve their own handler at this same path, backed by in-memory worker state rather than the database, and workers do not serve `/api/v1/readyz` at all. For which endpoint belongs on which probe, see the [production deployment checklist](/self-host/production-deployment-checklist#health-probes).
 
 Confirm the version too, then upgrade the [Lightdash CLI](/guides/cli/how-to-upgrade-cli) to match.
 </Step>


### PR DESCRIPTION
## Why

Lightdash serves three health endpoints. The docs described them only as things you `curl` after a deploy. Nothing said how to **configure** them, and one version fence was missing in a way that can cause an outage.

## What changes

**1. The missing version fence, in `upgrade-runbook.mdx`.**

The "What shipped when" table said the probes exist from `1.129.0`. True, but not the version from which pointing a readiness probe at `/api/v1/readyz` is safe. Until `1.169.1` a parked migration marked working pods as not ready, so one stuck migration removed the whole backend from the load balancer.

Adds the row and a warning naming the affected range.

**2. A "Health probes" section in `production-deployment-checklist.mdx`.**

That page had no probe content at all, and it is the page a platform engineer reads when setting up. Adds a probe/endpoint/why table, the Helm values, the version fence, and the worker caveat.

**3. The `/api/v1/health` meaning, in the runbook.**

It is a fine manual check and a poor probe. And on **worker** pods it is a different handler entirely: in-memory worker state, no database query. Workers do not serve `/api/v1/readyz`. Same path, different meaning depending on which pod answers, which was undocumented.

## Verification

- Every version number matches the source: `1.129.0` for the endpoints existing, `1.169.1` for the parked-migration fix (lightdash PR #27476).
- Both cross-page anchors resolve to real headings.
- No em dashes in the diff.
- Docs only, two files.

## Related

Pairs with helm-charts#161, which makes `/api/v1/readyz` the resolved default on `1.169.1` and later. This PR is written to be correct whether or not that one lands, since it instructs setting the value explicitly.

Linear: SPK-1148