### PR TITLE
feat(nav): improve landing page and external links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -12,13 +12,13 @@
     "tabs": [
       {
         "tab": "Docs",
-        "groups": [
+        "pages": [
+          "introduction",
           {
             "group": "Get started",
             "root": "get-started",
             "directory": "card",
             "pages": [
-              "introduction",
               {
                 "group": "Quickstart",
                 "root": "get-started/quickstart",
@@ -461,26 +461,7 @@
           }
         ]
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "About Us",
-          "href": "https://www.lightdash.com/about",
-          "icon": "users"
-        },
-        {
-          "anchor": "Community",
-          "href": "https://join.slack.com/t/lightdash-community/shared_invite/zt-3pbwqmq5e-vhTc7HHcS787w618ngoPHA",
-          "icon": "slack"
-        },
-        {
-          "anchor": "Blog",
-          "href": "https://www.lightdash.com/blog",
-          "icon": "newspaper"
-        }
-      ]
-    }
+    ]
   },
   "logo": {
     "light": "/logo/light.svg",
@@ -516,7 +497,26 @@
       "slack": "https://join.slack.com/t/lightdash-community/shared_invite/zt-3pbwqmq5e-vhTc7HHcS787w618ngoPHA",
       "linkedin": "https://www.linkedin.com/company/lightdash/",
       "x": "https://x.com/lightdash_devs"
-    }
+    },
+    "links": [
+      {
+        "header": "Lightdash",
+        "items": [
+          {
+            "label": "About us",
+            "href": "https://www.lightdash.com/about"
+          },
+          {
+            "label": "Community",
+            "href": "https://join.slack.com/t/lightdash-community/shared_invite/zt-3pbwqmq5e-vhTc7HHcS787w618ngoPHA"
+          },
+          {
+            "label": "Blog",
+            "href": "https://www.lightdash.com/blog"
+          }
+        ]
+      }
+    ]
   },
   "fonts": {
     "heading": {

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,14 +6,16 @@ mode: "wide"
 
 At its core, Lightdash builds a shared understanding of your data and your business — a single source of truth for what everything means. The more your team uses Lightdash, the richer and smarter that foundation becomes.
 
-Lightdash then allows your team to use conversational analytics, build dashboards, and custom data apps all with an AI-powered experience that means they don't need to write any SQL. Everything is built from a single source of truth, so you have lineage for every data asset and can trace any query to it's official definition.
+Lightdash then allows your team to use conversational analytics, build dashboards, and custom data apps all with an AI-powered experience that means they don't need to write any SQL. Everything is built from a single source of truth, so you have lineage for every data asset and can trace any query to its official definition.
 
-Everything you create in Lightdash can be shared instantly with your team with control over roles, permissions and row-level security to make sure people see all the data they need and nothing more.
+Everything you create in Lightdash can be shared instantly with your team with control over roles, permissions, and row-level security to make sure people see all the data they need and nothing more.
 
-We'd love you to [join our Slack Community](https://join.slack.com/t/lightdash-community/shared_invite/zt-3pbwqmq5e-vhTc7HHcS787w618ngoPHA) to get access to help directly from the team, see sneak previews of new features, and give us your feedback. You can also read the [Lightdash blog](https://www.lightdash.com/blog) for product deep dives and analytics engineering practice, or [meet the team](https://www.lightdash.com/about) building it.
+<Callout icon="robot" color="#9990C4">
+**Talk to the docs with your agent** over MCP, no authentication required. Get [step-by-step instructions here](/agents/lightdash-mcp#lightdash-docs-mcp).
+</Callout>
 
-<Card title="Read these docs with your AI agent" icon="robot" href="/agents/lightdash-mcp#lightdash-docs-mcp">
-  These docs are served over a hosted MCP server at `https://docs.lightdash.com/mcp`, so an agent can read them directly. No authentication required.
-</Card>
-
+<Frame>
 <iframe src="https://www.youtube.com/embed/LPsHglF_b-E" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+</Frame>
+
+[Join our Slack Community](https://join.slack.com/t/lightdash-community/shared_invite/zt-3pbwqmq5e-vhTc7HHcS787w618ngoPHA) to share ideas with other Lightdash users and [the team](https://www.lightdash.com/about). To stay on top of new features, events, and analytics engineering deep dives, follow the [Lightdash blog](https://www.lightdash.com/blog).


### PR DESCRIPTION
* The refactor meant the intro page moved from the index spot, this restores it as its own top-level ungrouped page at the top of the nav, and thus the landing page
* Lightly improves copy and adds better use of Mintlify components like frames and custom callouts
* Reorder landing content for better flow and earlier MCP callout
* Moves Slack, blog, and about pages to footer instead of top of nav, adds mention in landing page copy to not bury them only in the footer, they're still highlighted for new users on the intro page