### PR TITLE
docs: document custom role presets

### DIFF
--- a/workspace-admin/custom-roles.mdx
+++ b/workspace-admin/custom-roles.mdx
@@ -70,21 +70,31 @@ This approach gives you precise control over what users can do in each project w
 1. Navigate to **Settings** → **General Settings** → **Custom Roles**
 2. You'll see a list of existing custom roles in your organization
 
-### Create a New Role from Scratch
+### Create a New Role
 
 1. Click **Create New Role**
-2. Enter a **Role Name** (e.g., "Marketing Analyst", "Finance Viewer")
-3. Add an optional **Description** to explain the role's purpose
-4. Select the **role type** — **Organization** or **Project**. This determines whether the role will be applied to a user or user group at the organization level or the project level. If you select **Organization**, both organization-only scopes and project scopes will be available. If you select **Project**, only project scopes will be available — organization-only scopes cannot be added to a project role. Once a role type has been selected, it cannot be changed — you'll need to create a new role if you want a different type.
-5. Select the specific **scopes** (permissions) you want to include:
+2. Select the **role type** — **Organization** or **Project**. This determines whether the role will be applied to a user or user group at the organization level or the project level. If you select **Organization**, both organization-only scopes and project scopes will be available. If you select **Project**, only project scopes will be available — organization-only scopes cannot be added to a project role. Once a role type has been selected, it cannot be changed — you'll need to create a new role if you want a different type.
+3. Choose a **Preset** that matches the role's purpose, or select **Start from scratch**. The preset list only shows options compatible with the selected role type.
+4. Review and edit the **Role Name**, optional **Description**, and selected **scopes**. Choosing a preset fills in these fields and automatically selects any scope dependencies.
+5. If you start from scratch, select the specific **scopes** (permissions) you want to include:
    - **View permissions**: Allow users to see content (dashboards, charts, spaces)
    - **Create permissions**: Allow users to create new content
    - **Manage permissions**: Allow users to edit, delete, or administer content
 6. Click **Save** to create the role
 
-<Frame>
-![create-new-role.png](/images/workspace-admin/custom-roles/create-new-role.png)
-</Frame>
+### Role presets
+
+Presets provide a starting point for common permission sets. Every populated field remains editable, and the saved custom role is independent of the preset. Changes to a preset in a future Lightdash release do not update roles created from it.
+
+| Preset | Role type | Purpose | Direct scopes |
+| --- | --- | --- | --- |
+| **Roadmap viewer** | Organization | View the organization's enterprise roadmap without organization administration permissions. | `view:Roadmap` |
+| **SQL Runner user** | Project | Run warehouse SQL through SQL Runner, AI agents, and MCP without project deployment or SQL-authoring permissions. | `manage:SqlRunner` |
+| **SQL author** | Project | Run warehouse SQL and author SQL charts, custom SQL dimensions, and SQL table calculations. | `manage:SqlRunner`, `manage:CustomSql`, `manage:CustomFields`, `manage:CustomSqlTableCalculations`, `view:CompiledSql` |
+| **Data App builder** | Project | Create Data Apps and manage the apps you build, including in production projects. | `create:DataApp` |
+| **AI agent manager** | Project | Create and manage all AI agents and their knowledge documents in assigned projects. | `manage:AiAgent`, `manage:AiAgentDocument` |
+
+The table lists the scopes defined directly by each preset. Lightdash also selects their required dependencies, so the role builder can show additional scopes after you choose a preset. If you change the role type and the selected preset is not compatible with the new type, the picker returns to **Start from scratch**.
 
 ### Scope dependencies
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10320

## Description:

Documents how organization and project role presets seed editable names, descriptions, direct scopes, and scope dependencies. Lists all five preset mappings, explains level filtering and preset independence, and removes the outdated pre-preset creation screenshot.

```text
Role type -> compatible preset -> editable fields and scopes -> independent custom role
```

Validation: `npm run check`, `npm run validate:docs`, and `npx mintlify broken-links`.