### PR TITLE
docs: role sets are part of custom roles, no separate enablement

### DIFF
--- a/workflow/content-as-code.mdx
+++ b/workflow/content-as-code.mdx
@@ -1041,9 +1041,9 @@ role:
 | `disabled` | `true` to deactivate the member, `false` to keep them active. Uploads never disable the last enabled authenticated admin. |
 | `role.type` | Either `system` or `custom`. `system` uses one of the built-in roles (`member`, `viewer`, `interactive_viewer`, `editor`, `developer`, `admin`); `custom` references a user-defined role. |
 | `role.name` | For `system`, the built-in role name. For `custom`, the exact organization-level custom role name — the referenced role must exist, or be created in the same upload's custom-roles phase. |
-| `additionalRoles` | Optional. Extra organization-level **custom** roles held on top of `role`, when [multiple roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled. Each entry is `{ type: custom, name: <role name> }`. Omitted on download when the user holds a single role. |
+| `additionalRoles` | Optional. Extra organization-level **custom** roles held on top of `role`, when [custom roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled. Each entry is `{ type: custom, name: <role name> }`. Omitted on download when the user holds a single role. |
 
-When multiple roles are enabled, a member with a system role plus extra custom roles serializes as:
+With custom roles enabled, a member with a system role plus extra custom roles serializes as:
 
 ```yaml
 version: 1
@@ -1059,7 +1059,7 @@ additionalRoles:
     name: sql-runner
 ```
 
-The file describes the member's **complete** organization role set: uploading a file without `additionalRoles` for a member who currently holds extra roles removes those extras. Uploads that contain `additionalRoles` require multiple roles to be enabled for the organization (the file fails with `403` otherwise), and instances that do not support the field reject it rather than silently dropping it.
+The file describes the member's **complete** organization role set: uploading a file without `additionalRoles` for a member who currently holds extra roles removes those extras. Uploads that contain `additionalRoles` require custom roles to be enabled for the organization (the file fails with `403` otherwise), and instances that do not support the field reject it rather than silently dropping it.
 
 Lifecycle status — whether a user has authenticated yet, whether they have a valid invitation — is derived from the destination user during upload and is not declared in YAML.
 

--- a/workspace-admin/custom-roles.mdx
+++ b/workspace-admin/custom-roles.mdx
@@ -153,7 +153,7 @@ Custom roles are assigned at the project level to provide granular access contro
 
 ## Assigning multiple roles (role sets)
 
-By default every user or group holds **one** role per level: one organization role, and at most one role per project. Enterprise organizations can ask Lightdash to enable **multiple roles**, which turns each of those single roles into a **role set**:
+By default every user or group holds **one** role per level: one organization role, and at most one role per project. On Enterprise plans with custom roles, each of those single roles becomes a **role set**:
 
 - **at most one system role** — the base (`viewer`, `editor`, `admin`, …), or none;
 - **any number of custom roles** of the matching level (organization or project), added on top.
@@ -170,12 +170,9 @@ Because permissions only add up, a system base is never narrowed by the custom r
 
 ### Eligibility
 
-Multiple roles require:
+Multiple roles are part of **custom roles**: they are available on any Lightdash **Enterprise** plan with custom roles enabled — no separate enablement is needed.
 
-- a Lightdash **Enterprise** plan with custom roles;
-- the **multiple roles** feature enabled for your organization — contact your Lightdash account team to switch it on.
-
-Until it is enabled, the role pickers, API endpoints and provisioning integrations behave exactly as before, with one role per level. Any extra roles that were assigned while the feature was on stay effective if it is later switched off — only the ability to *manage* sets is gated.
+Without custom roles, the role pickers, API endpoints and provisioning integrations behave exactly as before, with one role per level. Any extra roles that were assigned while custom roles were enabled stay effective if custom roles are later switched off — only the ability to *manage* sets is gated.
 
 ### In the UI
 
@@ -191,7 +188,7 @@ Invitations and the "add access" dialogs still assign a single role; add more ro
 
 ### Via the API
 
-Three `v2` endpoints read and replace a whole set atomically. They return `403` when multiple roles are not enabled for the organization.
+Three `v2` endpoints read and replace a whole set atomically. They return `403` when custom roles are not enabled for the organization.
 
 | Level | Endpoint |
 | --- | --- |
@@ -233,7 +230,7 @@ The existing single-role endpoints keep working. Their responses report the **pr
 
 ### Troubleshooting multiple roles
 
-- **`403 Multiple roles are not enabled`** on the `…/set` endpoints — the feature is not switched on for the organization; single-role behaviour applies.
+- **`403 Custom roles are not enabled`** on the `…/set` endpoints — custom roles are not enabled for the organization; single-role behaviour applies.
 - **`400 A role set must contain at least one role`** — send at least one system or custom role, or use the remove-access endpoint / trash action to drop the assignment.
 - **A user lost their extra roles** — a single-role write (an older client, script, or IdP payload) replaced the set. Re-assign the extras with the picker or the `…/set` endpoint.
 - **A custom role in the set does not seem to restrict anything** — sets are additive; check whether a system role sits in the same set or at the organization level. See [How additive permissions work](#how-additive-permissions-work).

--- a/workspace-admin/sso/scim.mdx
+++ b/workspace-admin/sso/scim.mdx
@@ -291,7 +291,7 @@ You can find the full API docs and examples for SCIM [here](/api-reference/scim/
 - `userName` is mapped to the user's primary email in Lightdash. Make sure your identity provider sets `userName` to the user's primary email (and, if sending an `emails` array, the primary email should match).
 - When a user is updated to be inactive (`active: false`) via SCIM, Lightdash will mark the user as inactive, lower their organization role to `member`, and remove their access from all projects and groups. If you later reactivate the user, you'll need to re-assign their group and project access via SCIM or in Lightdash.
 - An organization must always have at least one `admin`. Any SCIM request that would leave the organization with no admins (for example, demoting or deactivating the sole remaining admin) will be rejected with an error.
-- A user can only have one role per organization and per project, unless [multiple roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization — see [Provisioning role sets](#provisioning-role-sets) below.
+- A user can only have one role per organization and per project, unless [custom roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization (which includes role sets) — see [Provisioning role sets](#provisioning-role-sets) below.
 - A user must have an organization role.
 - On creation, if no `roles` are provided, the organization role will default to `member`.
 - On edit (PUT/PATCH), if no `roles` are provided, no changes are made to the user's roles.
@@ -396,7 +396,7 @@ Examples:
 
 ### Provisioning role sets
 
-When [multiple roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization, the same `roles` array can carry a complete **role set** per level: at most one system role plus any number of custom roles for the organization, and likewise per project. No Lightdash-specific schema extension is needed.
+When [custom roles](/workspace-admin/custom-roles#assigning-multiple-roles-role-sets) are enabled for the organization, the same `roles` array can carry a complete **role set** per level: at most one system role plus any number of custom roles for the organization, and likewise per project. No Lightdash-specific schema extension is needed.
 
 **Reading.** `GET /Users` and `GET /Users/{id}` list every role the user holds. The organization's system role (or its only custom role) is marked `"primary": true`; every additional role is `"primary": false`.
 
@@ -416,10 +416,10 @@ When [multiple roles](/workspace-admin/custom-roles#assigning-multiple-roles-rol
 - Identical entries are de-duplicated. A payload with no organization entry, more than one system organization role, or more than one system role for the same project is rejected with `400`.
 - Deactivating a user (`active: false`) still clears their roles as described above.
 
-While the feature is disabled, a `roles` array with more than one entry per level is rejected exactly as before, so existing IdP mappings do not change behaviour until you opt in.
+Without custom roles, a `roles` array with more than one entry per level is rejected exactly as before, so existing IdP mappings do not change behaviour.
 
 <Warning>
-  A payload with a **single** role per level (the legacy shape) replaces the whole set with that one role. If your IdP is the source of truth, make sure every role a user should keep is present in its `roles` mapping before enabling multiple roles.
+  A payload with a **single** role per level (the legacy shape) replaces the whole set with that one role. If your IdP is the source of truth, make sure every role a user should keep is present in its `roles` mapping before enabling custom roles.
 </Warning>
 
 ### Configuring available roles in your Identity Provider (IdP)


### PR DESCRIPTION
Companion to lightdash/lightdash#27743, which removes the `multiple-roles` feature flag and gates role sets on **custom roles** instead.

- `workspace-admin/custom-roles.mdx` — eligibility: Enterprise + custom roles, no separate enablement / "contact your account team" step; `403` messages updated (`Custom roles are not enabled`).
- `workspace-admin/sso/scim.mdx` — multi-role SCIM payloads accepted whenever custom roles are enabled; warning reworded.
- `workflow/content-as-code.mdx` — `additionalRoles` requires custom roles.

`validate.ts` passes (0 errors). Hold merging until the lightdash PR is released, since docs deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)