### PR TITLE
docs: mention threadRetentionHours in agents-as-code field reference

### DIFF
--- a/agents/agents-as-code.mdx
+++ b/agents/agents-as-code.mdx
@@ -137,6 +137,7 @@ evaluations:
 | `enableContentTools` | boolean | Whether the agent can create and edit charts and dashboards. See [creating & editing content](/agents/enable-content-tools). |
 | `enableUserContext` | boolean | Whether the agent receives the asking user's identity for [personalized answers](/agents/data-access#personalizing-answers-to-who-is-asking). |
 | `modelConfig` | object \| null | Default model settings: `modelName`, `modelProvider`, and optional `reasoning` flag. When `null`, the agent inherits the [organization default](/agents/set-up-agents#set-an-organization-default-ai-model). |
+| `threadRetentionHours` | number \| null (optional) | Per-agent [conversation retention](/agents/data-retention) window. Only applies when the feature is enabled for your organization — see [agents as code semantics](/agents/data-retention#agents-as-code). |
 | `evaluations` | object[] (optional) | Evaluation suite definitions to create or update by title. Downloads include this field even when the agent has no suites (`evaluations: []`). |
 
 ### Evaluation suites


### PR DESCRIPTION
The agents-as-code field reference didn't list the new `threadRetentionHours` key added for conversation retention. Adds one row pointing to the data-retention page, which carries the full semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)