### PR TITLE
docs: rename data retention page to thread retention

### DIFF
--- a/agents/agents-as-code.mdx
+++ b/agents/agents-as-code.mdx
@@ -137,7 +137,7 @@ evaluations:
 | `enableContentTools` | boolean | Whether the agent can create and edit charts and dashboards. See [creating & editing content](/agents/enable-content-tools). |
 | `enableUserContext` | boolean | Whether the agent receives the asking user's identity for [personalized answers](/agents/data-access#personalizing-answers-to-who-is-asking). |
 | `modelConfig` | object \| null | Default model settings: `modelName`, `modelProvider`, and optional `reasoning` flag. When `null`, the agent inherits the [organization default](/agents/set-up-agents#set-an-organization-default-ai-model). |
-| `threadRetentionHours` | number \| null (optional) | Per-agent [conversation retention](/agents/data-retention) window. Only applies when the feature is enabled for your organization — see [agents as code semantics](/agents/data-retention#agents-as-code). |
+| `threadRetentionHours` | number \| null (optional) | Per-agent [thread retention](/agents/thread-retention) window. Only applies when the feature is enabled for your organization — see [agents as code semantics](/agents/thread-retention#agents-as-code). |
 | `evaluations` | object[] (optional) | Evaluation suite definitions to create or update by title. Downloads include this field even when the agent has no suites (`evaluations: []`). |
 
 ### Evaluation suites

--- a/agents/thread-retention.mdx
+++ b/agents/thread-retention.mdx
@@ -12,15 +12,13 @@ doc-type: reference
   variables](/self-host/customize-deployment/environment-variables#feature-flags).
 </Info>
 
-By default, Lightdash keeps AI agent threads — conversations with an agent —
-forever. Organizations with
+By default, Lightdash keeps AI agent threads forever. Organizations with
 compliance or privacy requirements can set a retention window instead:
 threads with no activity for the configured period are automatically and
 permanently deleted, once per hour.
 
-The retention window applies to threads — the questions people ask and
-the agent's replies — not to your warehouse. Your data stays in your warehouse
-under your own policies, and this setting never touches it.
+Retention only applies to threads, never to your warehouse data, which stays
+in your warehouse under your own policies.
 
 ## How retention works
 

--- a/agents/thread-retention.mdx
+++ b/agents/thread-retention.mdx
@@ -1,21 +1,26 @@
 ---
-title: Data retention
-description: Automatically delete AI agent conversations after a period of inactivity
+title: Thread retention
+description: Automatically delete AI agent threads after a period of inactivity
 doc-type: reference
 ---
 
 <Info>
-  Conversation retention is an Enterprise feature, enabled per organization on
+  Thread retention is an Enterprise feature, enabled per organization on
   request — [contact us](/support) to turn it on. Self-hosted Enterprise
   deployments set `LIGHTDASH_ENABLE_FEATURE_FLAGS=ai-thread-retention` — see
   [feature flag environment
   variables](/self-host/customize-deployment/environment-variables#feature-flags).
 </Info>
 
-By default, Lightdash keeps AI agent conversations forever. Organizations with
-data-retention or PII requirements can set a retention window instead:
-conversations with no activity for the configured period are automatically and
+By default, Lightdash keeps AI agent threads — conversations with an agent —
+forever. Organizations with
+compliance or privacy requirements can set a retention window instead:
+threads with no activity for the configured period are automatically and
 permanently deleted, once per hour.
+
+The retention window applies to threads — the questions people ask and
+the agent's replies — not to your warehouse. Your data stays in your warehouse
+under your own policies, and this setting never touches it.
 
 ## How retention works
 
@@ -23,33 +28,33 @@ Retention is configured in whole hours (presets from 1 hour to 90 days, or a
 custom value), at two levels:
 
 - **Organization default** — applies to every agent in the organization,
-  including conversations that aren't linked to an agent.
+  including threads that aren't linked to an agent.
 - **Per-agent window** — an agent can set a *shorter* window than the
   organization default, making the organization value the ceiling.
 
-The clock is based on **inactivity**: a conversation expires only when it has
+The clock is based on **inactivity**: a thread expires only when it has
 had no new messages for the whole window, measured from its latest activity.
 
 ## What gets deleted
 
-When a conversation expires, everything derived from it is deleted with it:
+When a thread expires, everything derived from it is deleted with it:
 
 - prompts, responses, tool calls and tool results, and reasoning
 - share links (revoked)
-- agent memories learned from the conversation
-- evaluation prompts that reference the conversation (evaluation suites may
-  shrink), and past evaluation runs' conversations
+- agent memories learned from the thread
+- evaluation prompts that reference the thread (evaluation suites may
+  shrink), and past evaluation runs' threads
 
-Content created from conversations, like saved charts and dashboards, is
+Content created from threads, like saved charts and dashboards, is
 stored independently and is not affected.
 
 Deletion is permanent. When an admin lowers the organization window, Lightdash
-shows how many conversations across how many agents will be deleted before the
+shows how many threads across how many agents will be deleted before the
 change is confirmed.
 
 ## What retention does not cover
 
-The retention window applies to AI agent conversation content stored by
+The retention window applies to AI agent thread content stored by
 Lightdash. Adjacent stores keep their own, separately bounded retention:
 
 | Store | Retention |
@@ -62,9 +67,9 @@ Lightdash. Adjacent stores keep their own, separately bounded retention:
 ## Configuring retention
 
 **Organization default**: go to **Organization settings** → **Ask AI** →
-**General** → **Conversation retention**. Lowering the window (or setting one
+**General** → **Thread retention**. Lowering the window (or setting one
 where there was none) asks for confirmation and shows how many existing
-conversations will be deleted.
+threads will be deleted.
 
 <Frame>
   <img
@@ -80,7 +85,7 @@ conversations will be deleted.
 </Frame>
 
 **Per-agent window**: in the agent's settings under **Permissions** →
-**Conversation retention**. When an organization default exists, it caps the
+**Thread retention**. When an organization default exists, it caps the
 values you can pick, and leaving the agent setting empty inherits the
 organization default.
 

--- a/docs.json
+++ b/docs.json
@@ -226,7 +226,7 @@
                   "agents/set-up-agents",
                   "agents/visibility",
                   "agents/data-access",
-                  "agents/data-retention",
+                  "agents/thread-retention",
                   "agents/enable-content-tools",
                   "agents/enable-ai-router",
                   "agents/lightdash-mcp",

--- a/self-host/customize-deployment/enterprise-license-keys.mdx
+++ b/self-host/customize-deployment/enterprise-license-keys.mdx
@@ -95,7 +95,7 @@ Set these on your Lightdash instance in addition to `LIGHTDASH_LICENSE_KEY`:
 | Embedding | `EMBEDDING_ENABLED=true` | Embed dashboards, charts, data apps, and AI agents into your own product | [Embedding](/embed/reference) · [env vars](/self-host/customize-deployment/environment-variables#embedding) |
 | Pre-aggregates | `preAggregateNatsWorker.enabled: true` | Materialize aggregated tables via a dedicated NATS worker and S3 bucket for faster dashboards | [Pre-aggregate workers](/self-host/nats-workers/pre-aggregate-workers) |
 | Data apps | See [self-hosting data apps](/self-host/data-apps) | AI-generated React apps built in an E2B sandbox and served from an S3 bucket | [Data apps self-hosting](/self-host/data-apps) |
-| Conversation retention | `ai-thread-retention` feature flag | Automatically delete AI agent conversations after a period of inactivity | [Data retention](/agents/data-retention) |
+| Thread retention | `ai-thread-retention` feature flag | Automatically delete AI agent threads after a period of inactivity | [Thread retention](/agents/thread-retention) |
 | AI writeback | `ai-writeback` feature flag | Let the AI agent open pull requests against your dbt repo to add or edit metrics | [AI writeback self-hosting](/agents/ai-writeback-self-hosting) |
 
 ### Enterprise SSO providers


### PR DESCRIPTION
'Data retention' reads as if Lightdash retains warehouse data, which could scare users evaluating the feature, and 'conversation' didn't match the UI or the API, which both say 'thread'. The page moves to /agents/thread-retention (no redirect — the old path was only live briefly) and the copy uses thread terminology throughout, with an intro line making explicit that the setting never touches warehouse data.

Pairs with lightdash/lightdash#27791, which aligns the in-app copy the screenshots show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)