### PR TITLE
docs: clarify data apps runtime requirement for project chart types

### DIFF
--- a/explore/chart-types/custom-project-charts.mdx
+++ b/explore/chart-types/custom-project-charts.mdx
@@ -15,7 +15,7 @@ A project chart type is a chart type you build once and reuse. Describe the char
 The same chart type can power many saved charts, each with its own query and field mapping.
 
 <Info>
-  Project chart types are an enterprise feature, enabled by default on Lightdash Cloud. Self-hosted instances need the [data apps runtime configured](/self-host/enterprise-features/data-apps).
+  Project chart types are an enterprise feature and require the [data apps runtime](/self-host/enterprise-features/data-apps) to be enabled.
 </Info>
 
 ## Browsing chart types


### PR DESCRIPTION
Removes the claim that project chart types are enabled by default on Lightdash Cloud. The callout now only states that the feature requires the data apps runtime to be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)