### PR TITLE
Document dashboard tile comments

### DIFF
--- a/explore/dashboards/interact.mdx
+++ b/explore/dashboards/interact.mdx
@@ -3,7 +3,7 @@ title: "Interacting with dashboards"
 description: "Filter, re-zoom, cross-filter, and drill into the charts on a dashboard without editing them"
 ---
 
-Everything on this page is something a viewer can do to a dashboard without editing it: narrow it with filters, change the time granularity of its charts, filter the whole dashboard by clicking a value in one chart, look at the rows behind a data point, and break a metric out by a dimension.
+Everything on this page is something a viewer can do to a dashboard without editing it: narrow it with filters, change the time granularity of its charts, filter the whole dashboard by clicking a value in one chart, look at the rows behind a data point, break a metric out by a dimension, and discuss a tile with your team in its comments.
 
 ## Filter the dashboard
 
@@ -76,3 +76,21 @@ Click **Open in new tab** for a chart of the metric grouped by `Shipping country
 <Frame>
   <img src="/images/explore/dashboards/interact/drill-into-result-day-eeb57dc6490792f406ae2d218e172706.png" alt="The drilled chart, showing the metric grouped by shipping country" />
 </Frame>
+
+## Comment on a tile
+
+Every chart, markdown, Loom, and data app tile carries its own comment thread. Hover over a tile and click the speech-bubble icon in its header to open the comments panel — on tiles that already have comments, the icon stays visible with a count, and the badge turns red when there are comments you haven't seen.
+
+Type `@` while writing a comment to mention someone; you can mention anyone who has access to the space the dashboard lives in. Replies sit under the comment they answer, one level deep.
+
+Who can do what follows your role:
+
+- Everyone who can see the dashboard can read its comments — there are no private comments.
+- Interactive viewers and above can post, reply, and delete their own comments.
+- Editors and above can resolve or unresolve a thread and delete anyone's comment. Resolving hides the whole thread behind the `Show resolved` toggle at the top of the panel.
+
+When someone mentions you, or comments on a tile you've commented on before, you get an in-app notification on the bell icon in the navigation bar. Clicking it opens the dashboard with that tile's comments panel open. There are no email notifications for comments.
+
+<Note>
+  Self-hosted deployments can turn dashboard comments off for everyone by setting `DISABLE_DASHBOARD_COMMENTS=true` on the backend.
+</Note>


### PR DESCRIPTION
Dashboard tile comments had no docs coverage anywhere. Adds a `Comment on a tile` section to `explore/dashboards/interact.mdx`: opening the panel, @-mentions (limited to people with access to the dashboard's space), one-level replies, the role split (read from viewer, post from interactive viewer, resolve/unresolve and delete-others from editor, own-comment delete for authors), in-app-only bell notifications, and the `DISABLE_DASHBOARD_COMMENTS` self-host opt-out.

Every claim verified against product source (CommentService, DashboardTileComments, the CASL ability files, NotificationsModel, parseConfig). Raised by the training team's coverage audit: lightdash-university#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GF8txWvDRwYoD9rigExBXN