### PR TITLE
Document creating a space

### DIFF
--- a/explore/spaces.mdx
+++ b/explore/spaces.mdx
@@ -16,6 +16,12 @@ To access Spaces, you can either select a Space from the drop-down list in `Brow
   ![The All spaces view, with a row per space showing its name and access level](/images/explore/spaces/view-all-spaces.png)
 </Frame>
 
+## Creating a Space
+
+Editors and above can create Spaces. Click `Add` on the `All spaces` page, or pick `Space` from the `+ New` menu in the navigation bar, then give the Space a name. Root-level Spaces also ask you to pick an access mode as you create them: `Inherited access` (everyone in the project, the default) or `Restricted access` (only invited users and groups) — see [managing access](#managing-access-to-a-space) for what each means.
+
+To create a nested Space, open the parent Space and pick `Create space` from its `Add` menu. A nested Space always starts with the same access as its parent; you can change that after creating it. Either way, you become an admin of the Space you created, and it appears in `Browse` and on the `All spaces` page alongside the rest.
+
 ## Moving items between Spaces
 
 To move a saved chart, dashboard or space between Spaces, you can click on the three dot menu (`...`) to the right of the item and pick the `Move` action. Or select items using checkboxes on the left and click `Move to Space`.


### PR DESCRIPTION
`explore/spaces.mdx` covered access modes, moving, renaming and deleting, but never the create action itself. Adds a `Creating a Space` section: entry points (`Add` on All spaces, `+ New` menu, a parent space's `Add` menu for nested), the access-mode choice on root spaces (Inherited default vs Restricted), forced inheritance for nested spaces with change-later, creator becomes space admin, and where the new space appears. Editors and above.

Verified against product source (SpaceActionModal, CreateSpaceModalContent, SpaceService, projectMemberAbility). Raised by the training team's coverage audit: lightdash-university#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GF8txWvDRwYoD9rigExBXN