### PR TITLE
Document the export result scope choice

### DIFF
--- a/explore/share-charts.mdx
+++ b/explore/share-charts.mdx
@@ -42,3 +42,15 @@ You can also download the results table as a CSV or an Excel spreadsheet, or exp
 <Frame>
   <img src="/images/explore/share-charts/export-results.png" alt="The results table export menu" />
 </Frame>
+
+### Choosing how many rows an export contains
+
+The download dialog also asks how the values should be written — `Formatted` keeps the table's presentation, `Raw` uses the underlying values — and, for interactive viewers and above, the **result scope**:
+
+- `Table rows` exports exactly the rows currently loaded in the table.
+- `All results` runs the query for the full result set.
+- `Custom` exports the number of rows you enter.
+
+Viewers don't get the result scope choice; their downloads contain the visible table rows.
+
+Every export is bounded by your organization's [export limits](/workspace-admin/export-limits): a CSV or Excel file can hold at most the configured number of cells (rows × columns), so `All results` means as many rows as fit under that cap, and a custom row count above it is reduced to it. Excel files are additionally capped at 1,000,000 rows. Exporting to Google Sheets has no row choice.


### PR DESCRIPTION
The download dialog's result scope (`Table rows` / `All results` / `Custom`) had no docs coverage. Extends the download section of `explore/share-charts.mdx`: the Formatted/Raw values choice, who sees the result scope (interactive viewer and above; viewers export the visible rows), how the org cell limits bound `All results` and reduce oversized custom counts, the 1,000,000-row Excel cap, and that Google Sheets export has no row choice.

Verified against product source (ExportResults/index.tsx, csvLimitUtils.ts, projectMemberAbility.ts). Deliberately does not promise a truncation warning: whether one is shown is disputed (C-02 in the training team's gap list). Raised by the coverage audit: lightdash-university#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GF8txWvDRwYoD9rigExBXN